### PR TITLE
added "expo"(spaces) style mode, with commandline option eg "skippy-xd -ad"

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -291,7 +291,6 @@ clientwin_create_scaled_image(ClientWin *cw)
 	int border = 0;
 	XSetWindowBorderWidth(cw->mainwin->ps->dpy, cw->mini.window, border);
 
-	printf("%d %d %d %d",cw->mini.x,cw->mini.y, cw->mini.width,cw->mini.height);
 	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window, cw->mini.x - border, cw->mini.y - border, cw->mini.width, cw->mini.height);
 	
 	if(cw->pixmap)
@@ -304,6 +303,20 @@ clientwin_create_scaled_image(ClientWin *cw)
 	XSetWindowBackgroundPixmap(cw->mainwin->ps->dpy, cw->mini.window, cw->pixmap);
 	
 	cw->destination = XRenderCreatePicture(cw->mainwin->ps->dpy, cw->pixmap, cw->mini.format, 0, 0);
+}
+
+
+void 
+clientwin_lerp_client_to_mini(ClientWin* cw,float t){
+	Rect2i dst_rc=skippywindow_rect(&cw->mini);
+	Rect2i src_rc=skippywindow_rect(&cw->client);
+	int	denom=1<<12;
+	int ti=(int)(t*(float)denom);
+	Rect2i rc;
+	rc.min=v2i_lerp(src_rc.min,dst_rc.min, ti, denom);
+	rc.max=v2i_lerp(src_rc.max,dst_rc.max, ti, denom);
+	skippywindow_set_rect(&cw->mini,&rc);
+
 }
 
 void

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -362,7 +362,7 @@ clientwin_unmap(ClientWin *cw)
 static void
 childwin_focus(ClientWin *cw)
 {
-	XWarpPointer(cw->mainwin->ps->dpy, None, cw->client.window, 0, 0, 0, 0, sw_width(cw) / 2, sw_height(cw) / 2);
+	XWarpPointer(cw->mainwin->ps->dpy, None, cw->client.window, 0, 0, 0, 0, sw_width(&cw->client) / 2, sw_height(&cw->client) / 2);
 	XRaiseWindow(cw->mainwin->ps->dpy, cw->client.window);
 	XSetInputFocus(cw->mainwin->ps->dpy, cw->client.window, RevertToParent, CurrentTime);
 }

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -316,7 +316,6 @@ clientwin_lerp_client_to_mini(ClientWin* cw,float t){
 	rc.min=v2i_lerp(src_rc.min,dst_rc.min, ti, denom);
 	rc.max=v2i_lerp(src_rc.max,dst_rc.max, ti, denom);
 	sw_set_rect(&cw->mini,&rc);
-
 }
 
 void
@@ -363,7 +362,7 @@ clientwin_unmap(ClientWin *cw)
 static void
 childwin_focus(ClientWin *cw)
 {
-	XWarpPointer(cw->mainwin->ps->dpy, None, cw->client.window, 0, 0, 0, 0, cw->client.width / 2, cw->client.height / 2);
+	XWarpPointer(cw->mainwin->ps->dpy, None, cw->client.window, 0, 0, 0, 0, sw_width(cw) / 2, sw_height(cw) / 2);
 	XRaiseWindow(cw->mainwin->ps->dpy, cw->client.window);
 	XSetInputFocus(cw->mainwin->ps->dpy, cw->client.window, RevertToParent, CurrentTime);
 }

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -308,14 +308,14 @@ clientwin_create_scaled_image(ClientWin *cw)
 
 void 
 clientwin_lerp_client_to_mini(ClientWin* cw,float t){
-	Rect2i dst_rc=skippywindow_rect(&cw->mini);
-	Rect2i src_rc=skippywindow_rect(&cw->client);
+	Rect2i dst_rc=sw_rect(&cw->mini);
+	Rect2i src_rc=sw_rect(&cw->client);
 	int	denom=1<<12;
 	int ti=(int)(t*(float)denom);
 	Rect2i rc;
 	rc.min=v2i_lerp(src_rc.min,dst_rc.min, ti, denom);
 	rc.max=v2i_lerp(src_rc.max,dst_rc.max, ti, denom);
-	skippywindow_set_rect(&cw->mini,&rc);
+	sw_set_rect(&cw->mini,&rc);
 
 }
 

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -31,7 +31,7 @@ clientwin_cmp_func(dlist *l, void *data)
 {
 	return ((ClientWin*)l->data)->client.window == (Window)data;
 }
-
+//int g_all_desktops=1;
 int
 clientwin_validate_func(dlist *l, void *data) {
 	ClientWin *cw = (ClientWin *)l->data;
@@ -41,9 +41,9 @@ clientwin_validate_func(dlist *l, void *data) {
 		w_desktop = wm_get_window_desktop(mw->ps->dpy, cw->client.window);
 	
 #ifdef CFG_XINERAMA
-	if(mw->xin_active && ! INTERSECTS(cw->client.x, cw->client.y, cw->client.width, cw->client.height,
+	if(mw->xin_active && (!INTERSECTS(cw->client.x, cw->client.y, cw->client.width, cw->client.height,
 	                                           mw->xin_active->x_org, mw->xin_active->y_org,
-	                                           mw->xin_active->width, mw->xin_active->height))
+	                                           mw->xin_active->width, mw->xin_active->height)))
 		return 0;
 #endif
 	

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -40,8 +40,9 @@ clientwin_validate_func(dlist *l, void *data) {
 	CARD32 desktop = (*(CARD32*)data),
 		w_desktop = wm_get_window_desktop(mw->ps->dpy, cw->client.window);
 	
+	// Todo: resolve how multi-desktops vs multi-monitor works.
 #ifdef CFG_XINERAMA
-	if(mw->xin_active && (!INTERSECTS(cw->client.x, cw->client.y, cw->client.width, cw->client.height,
+	if(!(mw->ps->o.xinerama_showAll) && mw->xin_active && (!INTERSECTS(cw->client.x, cw->client.y, cw->client.width, cw->client.height,
 	                                           mw->xin_active->x_org, mw->xin_active->y_org,
 	                                           mw->xin_active->width, mw->xin_active->height)))
 		return 0;
@@ -380,6 +381,8 @@ clientwin_unmap(ClientWin *cw)
 static void
 childwin_focus(ClientWin *cw)
 {
+	// how to handle it offscreen? need to map to screen coords, if its outside, do this warp in screen space
+//	if (!cw->mainwin->ps->o.xinerama_showAll)
 	XWarpPointer(cw->mainwin->ps->dpy, None, cw->client.window, 0, 0, 0, 0, sw_width(&cw->client) / 2, sw_height(&cw->client) / 2);
 	XRaiseWindow(cw->mainwin->ps->dpy, cw->client.window);
 	XSetInputFocus(cw->mainwin->ps->dpy, cw->client.window, RevertToParent, CurrentTime);
@@ -425,7 +428,7 @@ clientwin_handle(ClientWin *cw, XEvent *ev) {
 				ps->o.layout_grid^=true;
 				if (!(ps->o.layout_grid)) { ps->o.xinerama_showAll^=true;}
 				g_redo_layout=1;
-			} else if (ev->xkey.keycode == cw->mainwin->key_page_up) {
+			} else if (ev->xkey.keycode == cw->mainwin->key_page_down) {
 				ps->o.layout_grid=true;
 				ps->o.xinerama_showAll=false;
 				g_redo_layout=1;

--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -262,16 +262,12 @@ clientwin_schedule_repair(ClientWin *cw, XRectangle *area)
 	cw->damaged = true;
 }
 
-void
-clientwin_move(ClientWin *cw, float f, int x, int y)
-{
-	/* int border = MAX(1, (double)DISTANCE(cw->mainwin) * f * 0.25); */
-	int border = 0;
-	XSetWindowBorderWidth(cw->mainwin->ps->dpy, cw->mini.window, border);
-	
+// This functionality moved into layout -"layout_run_scale_all".
+void clientwin_move_sub(ClientWin* cw, int dx,int dy,float f) {
+
 	cw->factor = f;
-	cw->mini.x = x + (int)cw->x * f;
-	cw->mini.y = y + (int)cw->y * f;
+	cw->mini.x = dx + (int)cw->x * f;
+	cw->mini.y = dy + (int)cw->y * f;
 	if(cw->mainwin->ps->o.lazyTrans)
 	{
 		cw->mini.x += cw->mainwin->x;
@@ -279,6 +275,23 @@ clientwin_move(ClientWin *cw, float f, int x, int y)
 	}
 	cw->mini.width = MAX(1, (int)cw->client.width * f);
 	cw->mini.height = MAX(1, (int)cw->client.height * f);
+
+}
+
+
+void
+clientwin_move_and_create_scaled_image(ClientWin *cw, float f, int dx, int dy) {
+	clientwin_move_sub(cw,  dx,dy,f);
+	clientwin_create_scaled_image( cw);
+}
+void
+clientwin_create_scaled_image(ClientWin *cw)
+{
+	/* int border = MAX(1, (double)DISTANCE(cw->mainwin) * f * 0.25); */
+	int border = 0;
+	XSetWindowBorderWidth(cw->mainwin->ps->dpy, cw->mini.window, border);
+
+	printf("%d %d %d %d",cw->mini.x,cw->mini.y, cw->mini.width,cw->mini.height);
 	XMoveResizeWindow(cw->mainwin->ps->dpy, cw->mini.window, cw->mini.x - border, cw->mini.y - border, cw->mini.width, cw->mini.height);
 	
 	if(cw->pixmap)

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -20,6 +20,40 @@
 #ifndef SKIPPY_CLIENT_H
 #define SKIPPY_CLIENT_H
 
+// 2d int maths helpers
+typedef struct Vec2i {	// todo: refactor to use this
+	int x,y;
+} Vec2i;
+
+typedef struct Rect2i {
+	Vec2i min,max;
+} Rect2i;
+
+inline int invlerpi(int lo,int hi,int v,int one) { return ((v-lo)*one)/(hi-lo);}
+inline int lerpi(int lo,int hi,int f,int one) { return lo+(((hi-lo)*f)/one);}
+inline void v2i_set(Vec2i* dst, int x, int y) { dst->x=x;dst->y=y;}
+inline Vec2i v2i_sub(Vec2i a,Vec2i b) { Vec2i ret= {b.x-a.x,b.y-a.y};return ret; }
+inline Vec2i v2i_add(Vec2i a,Vec2i b) { Vec2i ret= {b.x+a.x,b.y+a.y};return ret; }
+inline Vec2i v2i_mul(Vec2i a,int f,int prec) { Vec2i ret= {(a.x*f)/prec,(a.y*f)/prec};return ret; }
+inline Vec2i v2i_mad(Vec2i a,Vec2i b,int f,int prec) { return v2i_add(a, v2i_mul(b,f,prec)); }
+inline Vec2i v2i_lerp(Vec2i a,Vec2i b,int f,int prec) { return v2i_add(a, v2i_mul(v2i_sub(b,a),f,prec)); }
+inline Vec2i v2i_invlerp(const Vec2i vmin,const Vec2i vmax, Vec2i v,int precision ) { Vec2i ret={invlerpi(vmin.x, vmax.x, v.x,precision), invlerpi(vmin.y, vmax.y, v.y,precision)}; return ret; }
+inline Vec2i rect2i_lerp(const Rect2i* r, Vec2i v, int precision) { Vec2i ret={lerpi(r->min.x,r->max.x, v.x,precision),lerpi(r->min.y,r->max.y, v.y,precision)}; return ret;}
+inline Vec2i rect2i_invlerp(const Rect2i* r, Vec2i v, int precision) { return v2i_invlerp(r->min,r->max, v, precision);}
+inline Vec2i v2i_min(Vec2i a,Vec2i b) { Vec2i ret={MIN(a.x,b.x),MIN(a.y,b.y)}; return ret;}
+inline Vec2i v2i_max(Vec2i a,Vec2i b) { Vec2i ret={MAX(a.x,b.x),MAX(a.y,b.y)}; return ret;}
+inline Rect2i rect2i_init(void){ Rect2i ret={{INT_MAX,INT_MAX},{-INT_MAX,-INT_MAX}}; return ret;}
+inline void rect2i_set_init(Rect2i* ret){  v2i_set(&ret->min,INT_MAX,INT_MAX);v2i_set(&ret->max,-INT_MAX,-INT_MAX); }
+inline void rect2i_include(Rect2i* r,Vec2i v){ r->min=v2i_min(r->min,v);r->max=v2i_max(r->max,v); }
+inline void rect2i_include_rect2i(Rect2i* r,const Rect2i* src){ r->min=v2i_min(r->min,src->min);r->max=v2i_max(r->max,src->max); }
+inline Vec2i rect2i_size(const Rect2i* r) { return v2i_sub(r->max,r->min);}
+inline int rect2i_aspect(const Rect2i* r,int precision) { Vec2i sz=rect2i_size(r); return (sz.x*precision)/sz.y;}
+inline Rect2i rect2i_add(const Rect2i* a, Vec2i ofs) { Rect2i ret={v2i_add(a->min,ofs),v2i_add(a->max,ofs)}; return ret;}
+inline int rect2i_area( const Rect2i* r) { Vec2i sz=rect2i_size(r); return (sz.x*sz.y);}
+inline Rect2i rect2i_intersect( const Rect2i* a,const Rect2i* b ) { Rect2i r; r.min=v2i_max(a->min,b->min); r.max=v2i_min(a->max,b->max); return r;}
+inline int rect2i_overlap( const Rect2i* a,const Rect2i* b) { Rect2i ri=rect2i_intersect(a,b);Vec2i sz= rect2i_size(&ri);if (sz.x>0 && sz.y>0) return sz.x*sz.y; else return 0;}
+inline bool rect2i_valid(const Rect2i* a) { return a->max.x>=a->min.x && a->max.y >= a->min.y; }
+
 typedef struct {
 	Window window;
 	int x, y;

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -166,6 +166,9 @@ inline Rect2i cw_client_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w
 inline Rect2i cw_client_mini_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w->mini),sw_size(&w->mini));}
 inline Vec2i cw_client_pos(const ClientWin* w)	{ return sw_pos(&w->client);}
 inline Vec2i cw_client_size(const ClientWin* w)	{ return sw_size(&w->client);}
-inline Vec2i cw_set_xy(ClientWin* w, int x, int y) { w->x = x; w->y=y;}
-inline Vec2i cw_set_pos(ClientWin* w, Vec2i pos) { w->x = pos.x; w->y=pos.y;}
+inline int cw_client_width(const ClientWin* w)	{ return sw_size(&w->client).x;}
+inline int cw_client_height(const ClientWin* w)	{ return sw_size(&w->client).y;}
+inline Vec2i cw_set_tmp_xy(ClientWin* w, int x, int y) { w->x = x; w->y=y;}
+inline Vec2i cw_set_tmp_pos(ClientWin* w, Vec2i pos) { w->x = pos.x; w->y=pos.y;}
+inline Vec2i cw_tmp_pos(ClientWin* w) { return vec2i_mk(w->x,w->y);}
 #endif /* SKIPPY_CLIENT_H */

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -29,6 +29,11 @@ typedef struct Rect2i {
 	Vec2i min,max;
 } Rect2i;
 
+typedef struct PosSize {
+	Vec2i pos,size;
+} PosSize;
+
+
 inline int invlerpi(int lo,int hi,int v,int one) { return ((v-lo)*one)/(hi-lo);}
 inline int lerpi(int lo,int hi,int f,int one) { return lo+(((hi-lo)*f)/one);}
 inline void v2i_set(Vec2i* dst, int x, int y) { dst->x=x;dst->y=y;}
@@ -59,6 +64,9 @@ inline bool rect2i_valid(const Rect2i* a) { return a->max.x>=a->min.x && a->max.
 inline void vec2i_print(const Vec2i v) { printf("(%d %d)", v.x,v.y);}
 inline void rect2i_print(const Rect2i* a) { printf("("); vec2i_print(a->min); printf(" "); vec2i_print(a->max); printf(")");}
 inline Vec2i rect2i_centre(const Rect2i* r) { return v2i_lerp(r->min,r->max,1,2);}
+inline PosSize pos_size_mk(const Vec2i pos, const Vec2i size) { PosSize psz;psz.pos=pos; psz.size=size; return psz;}
+inline PosSize pos_size_from_rect(const Rect2i* r) { PosSize psz;psz.pos=r->min; psz.size=rect2i_size(r); return psz;}
+inline Rect2i rect2i_from_pos_size(const PosSize* psz) { rect2i_mk_at(psz->pos, psz->size);}
 typedef struct {
 	Window window;
 	int x, y;
@@ -119,13 +127,16 @@ void
 clientwin_lerp_client_to_mini(ClientWin* cw,float t);
 
 // accessors, less needed if code is refactored to use vec2i etc.
-inline Vec2i skippywindow_pos(const SkippyWindow* w)	{ return vec2i_mk(w->x,w->y); }
-inline Vec2i skippywindow_size(const SkippyWindow* w)	{ return vec2i_mk(w->width,w->height); }
-inline Rect2i skippywindow_rect(const SkippyWindow* w)	{ return rect2i_mk_at(skippywindow_pos(w),skippywindow_size(w));}
-inline void skippywindow_set_pos(SkippyWindow* sw, const Vec2i p) { sw->x=p.x; sw->y=p.y; }
-inline void skippywindow_set_rect(SkippyWindow* sw, const Rect2i* r) { skippywindow_set_pos(sw,r->min); sw->width=r->max.x-r->min.x; sw->height=r->max.y-r->min.y;}
-inline Rect2i clientwin_rect(const ClientWin* w)	{ return rect2i_mk_at(skippywindow_pos(&w->client),skippywindow_size(&w->client));}
-inline Rect2i clientwin_mini_rect(const ClientWin* w)	{ return rect2i_mk_at(skippywindow_pos(&w->mini),skippywindow_size(&w->mini));}
-inline Vec2i clientwin_pos(const ClientWin* w)	{ return skippywindow_pos(&w->client);}
-inline Vec2i clientwin_size(const ClientWin* w)	{ return skippywindow_size(&w->client);}
+inline Vec2i sw_pos(const SkippyWindow* w)	{ return vec2i_mk(w->x,w->y); }
+inline Vec2i sw_size(const SkippyWindow* w)	{ return vec2i_mk(w->width,w->height); }
+inline Rect2i sw_rect(const SkippyWindow* w)	{ return rect2i_mk_at(sw_pos(w),sw_size(w));}
+inline PosSize sw_pos_size(const SkippyWindow* w)	{ return pos_size_mk(sw_pos(w),sw_size(w));}
+inline void sw_set_pos(SkippyWindow* sw, const Vec2i p) { sw->x=p.x; sw->y=p.y; }
+inline void sw_set_size(SkippyWindow* sw, const Vec2i sz) { sw->width=sz.x; sw->height=sz.y; }
+inline void sw_set_rect(SkippyWindow* sw, const Rect2i* r) { sw_set_pos(sw,r->min); sw->width=r->max.x-r->min.x; sw->height=r->max.y-r->min.y;}
+inline void sw_set_pos_size(SkippyWindow* sw, const Vec2i p,const Vec2i sz) { sw_set_pos(sw,p); sw_set_size(sw,sz);}
+inline Rect2i clientwin_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w->client),sw_size(&w->client));}
+inline Rect2i clientwin_mini_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w->mini),sw_size(&w->mini));}
+inline Vec2i clientwin_pos(const ClientWin* w)	{ return sw_pos(&w->client);}
+inline Vec2i clientwin_size(const ClientWin* w)	{ return sw_size(&w->client);}
 #endif /* SKIPPY_CLIENT_H */

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -33,8 +33,8 @@ inline int invlerpi(int lo,int hi,int v,int one) { return ((v-lo)*one)/(hi-lo);}
 inline int lerpi(int lo,int hi,int f,int one) { return lo+(((hi-lo)*f)/one);}
 inline void v2i_set(Vec2i* dst, int x, int y) { dst->x=x;dst->y=y;}
 inline Vec2i vec2i_mk(int x, int y) { Vec2i v; v.x=x; v.y=y; return v;}
-inline Vec2i v2i_sub(Vec2i a,Vec2i b) { Vec2i ret= {b.x-a.x,b.y-a.y};return ret; }
-inline Vec2i v2i_add(Vec2i a,Vec2i b) { Vec2i ret= {b.x+a.x,b.y+a.y};return ret; }
+inline Vec2i v2i_sub(Vec2i a,Vec2i b) { Vec2i ret= {a.x-b.x,a.y-b.y};return ret; }
+inline Vec2i v2i_add(Vec2i a,Vec2i b) { Vec2i ret= {a.x+b.x,a.y+b.y};return ret; }
 inline Vec2i v2i_mul(Vec2i a,int f,int prec) { Vec2i ret= {(a.x*f)/prec,(a.y*f)/prec};return ret; }
 inline Vec2i v2i_mad(Vec2i a,Vec2i b,int f,int prec) { return v2i_add(a, v2i_mul(b,f,prec)); }
 inline Vec2i v2i_lerp(Vec2i a,Vec2i b,int f,int prec) { return v2i_add(a, v2i_mul(v2i_sub(b,a),f,prec)); }
@@ -47,7 +47,7 @@ inline Rect2i rect2i_init(void){ Rect2i ret={{INT_MAX,INT_MAX},{-INT_MAX,-INT_MA
 inline Rect2i rect2i_mk_at(Vec2i pos, Vec2i size){ Rect2i ret; ret.min=pos; ret.max=v2i_add(pos,size);  return ret;}
 inline Rect2i rect2i_mk(Vec2i a, Vec2i b){ Rect2i ret; ret.min=a; ret.max=b;  return ret;}
 inline void rect2i_set_init(Rect2i* ret){  v2i_set(&ret->min,INT_MAX,INT_MAX);v2i_set(&ret->max,-INT_MAX,-INT_MAX); }
-inline void rect2i_include(Rect2i* r,Vec2i v){ r->min=v2i_min(r->min,v);r->max=v2i_max(r->max,v); }
+inline void rect2i_include(Rect2i* r,Vec2i v){ r->min=v2i_min(r->min,v); r->max=v2i_max(r->max,v); }
 inline void rect2i_include_rect2i(Rect2i* r,const Rect2i* src){ r->min=v2i_min(r->min,src->min);r->max=v2i_max(r->max,src->max); }
 inline Vec2i rect2i_size(const Rect2i* r) { return v2i_sub(r->max,r->min);}
 inline int rect2i_aspect(const Rect2i* r,int precision) { Vec2i sz=rect2i_size(r); return (sz.x*precision)/sz.y;}
@@ -56,6 +56,8 @@ inline int rect2i_area( const Rect2i* r) { Vec2i sz=rect2i_size(r); return (sz.x
 inline Rect2i rect2i_intersect( const Rect2i* a,const Rect2i* b ) { Rect2i r; r.min=v2i_max(a->min,b->min); r.max=v2i_min(a->max,b->max); return r;}
 inline int rect2i_overlap( const Rect2i* a,const Rect2i* b) { Rect2i ri=rect2i_intersect(a,b);Vec2i sz= rect2i_size(&ri);if (sz.x>0 && sz.y>0) return sz.x*sz.y; else return 0;}
 inline bool rect2i_valid(const Rect2i* a) { return a->max.x>=a->min.x && a->max.y >= a->min.y; }
+inline void vec2i_print(const Vec2i v) { printf("(%d %d)", v.x,v.y);}
+inline void rect2i_print(const Rect2i* a) { printf("("); vec2i_print(a->min); printf(" "); vec2i_print(a->max); printf(")");}
 
 typedef struct {
 	Window window;
@@ -100,6 +102,9 @@ int clientwin_sort_func(dlist *, dlist *, void *);
 ClientWin *clientwin_create(struct _MainWin *, Window);
 void clientwin_destroy(ClientWin *, bool destroyed);
 void clientwin_move(ClientWin *, float, int, int);
+void clientwin_create_scaled_image(ClientWin *cw);
+void clientwin_move_and_create_scaled_image(ClientWin *cw, float f, int dx, int dy);
+
 void clientwin_map(ClientWin *);
 void clientwin_unmap(ClientWin *);
 int clientwin_handle(ClientWin *, XEvent *);
@@ -110,9 +115,10 @@ void clientwin_render(ClientWin *);
 void clientwin_schedule_repair(ClientWin *cw, XRectangle *area);
 void clientwin_repair(ClientWin *cw);
 // accessors, less needed if code is refactored to use vec2i etc.
-inline Vec2i skippywindow_pos(const SkippyWindow* w)	{ vec2i_mk(w->x,w->y); }
-inline Vec2i skippywindow_size(const SkippyWindow* w)	{ vec2i_mk(w->width,w->height); }
+inline Vec2i skippywindow_pos(const SkippyWindow* w)	{ return vec2i_mk(w->x,w->y); }
+inline Vec2i skippywindow_size(const SkippyWindow* w)	{ return vec2i_mk(w->width,w->height); }
 inline Rect2i clientwin_rect(const ClientWin* w)	{ return rect2i_mk_at(skippywindow_pos(&w->client),skippywindow_size(&w->client));}
 inline Rect2i clientwin_mini_rect(const ClientWin* w)	{ return rect2i_mk_at(skippywindow_pos(&w->mini),skippywindow_size(&w->mini));}
-
+inline Vec2i clientwin_pos(const ClientWin* w)	{ return skippywindow_pos(&w->client);}
+inline Vec2i clientwin_size(const ClientWin* w)	{ return skippywindow_size(&w->client);}
 #endif /* SKIPPY_CLIENT_H */

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -58,7 +58,7 @@ inline int rect2i_overlap( const Rect2i* a,const Rect2i* b) { Rect2i ri=rect2i_i
 inline bool rect2i_valid(const Rect2i* a) { return a->max.x>=a->min.x && a->max.y >= a->min.y; }
 inline void vec2i_print(const Vec2i v) { printf("(%d %d)", v.x,v.y);}
 inline void rect2i_print(const Rect2i* a) { printf("("); vec2i_print(a->min); printf(" "); vec2i_print(a->max); printf(")");}
-
+inline Vec2i rect2i_centre(const Rect2i* r) { return v2i_lerp(r->min,r->max,1,2);}
 typedef struct {
 	Window window;
 	int x, y;
@@ -114,9 +114,16 @@ int clientwin_check_group_leader_func(dlist *l, void *data);
 void clientwin_render(ClientWin *);
 void clientwin_schedule_repair(ClientWin *cw, XRectangle *area);
 void clientwin_repair(ClientWin *cw);
+
+void 
+clientwin_lerp_client_to_mini(ClientWin* cw,float t);
+
 // accessors, less needed if code is refactored to use vec2i etc.
 inline Vec2i skippywindow_pos(const SkippyWindow* w)	{ return vec2i_mk(w->x,w->y); }
 inline Vec2i skippywindow_size(const SkippyWindow* w)	{ return vec2i_mk(w->width,w->height); }
+inline Rect2i skippywindow_rect(const SkippyWindow* w)	{ return rect2i_mk_at(skippywindow_pos(w),skippywindow_size(w));}
+inline void skippywindow_set_pos(SkippyWindow* sw, const Vec2i p) { sw->x=p.x; sw->y=p.y; }
+inline void skippywindow_set_rect(SkippyWindow* sw, const Rect2i* r) { skippywindow_set_pos(sw,r->min); sw->width=r->max.x-r->min.x; sw->height=r->max.y-r->min.y;}
 inline Rect2i clientwin_rect(const ClientWin* w)	{ return rect2i_mk_at(skippywindow_pos(&w->client),skippywindow_size(&w->client));}
 inline Rect2i clientwin_mini_rect(const ClientWin* w)	{ return rect2i_mk_at(skippywindow_pos(&w->mini),skippywindow_size(&w->mini));}
 inline Vec2i clientwin_pos(const ClientWin* w)	{ return skippywindow_pos(&w->client);}

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -85,6 +85,14 @@ clientwin_lerp_client_to_mini(ClientWin* cw,float t);
 
 // accessors, less needed if code is refactored to use vec2i etc.
 // bloats the headers whilst the change is in progress, can be search-replaced when done
+//
+// abreviations:
+//
+//	sw_ SkippyWindow
+//
+// cw_ ClientWindow
+// mw_ MainWindow
+  
 #ifdef SW_POS_SIZE
 inline Vec2i sw_pos(const SkippyWindow* w)	{ return w->rect.pos; }
 inline Vec2i sw_size(const SkippyWindow* w)	{ return w->rect.size; }

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -20,57 +20,6 @@
 #ifndef SKIPPY_CLIENT_H
 #define SKIPPY_CLIENT_H
 
-// 2d int maths helpers
-typedef struct Vec2i {	// todo: refactor to use this
-	int x,y;
-} Vec2i;
-
-typedef struct Rect2i {
-	Vec2i min,max;
-} Rect2i;
-
-typedef struct PosSize {
-	Vec2i pos,size;
-} PosSize;
-
-
-inline int invlerpi(int lo,int hi,int v,int one) { return ((v-lo)*one)/(hi-lo);}
-inline int lerpi(int lo,int hi,int f,int one) { return lo+(((hi-lo)*f)/one);}
-inline void v2i_set(Vec2i* dst, int x, int y) { dst->x=x;dst->y=y;}
-inline Vec2i vec2i_mk(int x, int y) { Vec2i v; v.x=x; v.y=y; return v;}
-inline Vec2i v2i_sub(Vec2i a,Vec2i b) { Vec2i ret= {a.x-b.x,a.y-b.y};return ret; }
-inline Vec2i v2i_add(Vec2i a,Vec2i b) { Vec2i ret= {a.x+b.x,a.y+b.y};return ret; }
-inline Vec2i v2i_mul(Vec2i a,int f,int prec) { Vec2i ret= {(a.x*f)/prec,(a.y*f)/prec};return ret; }
-inline Vec2i v2i_avr(Vec2i a,Vec2i b) { Vec2i ret=v2i_mul(v2i_add(a,b),1,2); return ret;}
-inline Vec2i v2i_mad(Vec2i a,Vec2i b,int f,int prec) { return v2i_add(a, v2i_mul(b,f,prec)); }
-inline Vec2i v2i_lerp(Vec2i a,Vec2i b,int f,int prec) { return v2i_add(a, v2i_mul(v2i_sub(b,a),f,prec)); }
-inline Vec2i v2i_invlerp(const Vec2i vmin,const Vec2i vmax, Vec2i v,int precision ) { Vec2i ret={invlerpi(vmin.x, vmax.x, v.x,precision), invlerpi(vmin.y, vmax.y, v.y,precision)}; return ret; }
-inline Vec2i rect2i_lerp(const Rect2i* r, Vec2i v, int precision) { Vec2i ret; ret.x=lerpi(r->min.x,r->max.x, v.x,precision); ret.y=lerpi(r->min.y,r->max.y, v.y,precision); return ret;}
-inline Vec2i rect2i_invlerp(const Rect2i* r, Vec2i v, int precision) { return v2i_invlerp(r->min,r->max, v, precision);}
-inline Vec2i v2i_min(Vec2i a,Vec2i b) { Vec2i ret={MIN(a.x,b.x),MIN(a.y,b.y)}; return ret;}
-inline Vec2i v2i_max(Vec2i a,Vec2i b) { Vec2i ret={MAX(a.x,b.x),MAX(a.y,b.y)}; return ret;}
-inline Rect2i rect2i_init(void){ Rect2i ret={{INT_MAX,INT_MAX},{-INT_MAX,-INT_MAX}}; return ret;}
-inline Rect2i rect2i_mk_at(Vec2i pos, Vec2i size){ Rect2i ret; ret.min=pos; ret.max=v2i_add(pos,size);  return ret;}
-inline Rect2i rect2i_mk_at_centre(Vec2i centre, Vec2i half_size){ Rect2i ret; ret.min=v2i_sub(centre,half_size); ret.max=v2i_add(centre,half_size);  return ret;}
-inline Rect2i rect2i_mk(Vec2i a, Vec2i b){ Rect2i ret; ret.min=a; ret.max=b;  return ret;}
-inline void rect2i_set_init(Rect2i* ret){  v2i_set(&ret->min,INT_MAX,INT_MAX);v2i_set(&ret->max,-INT_MAX,-INT_MAX); }
-inline void rect2i_include(Rect2i* r,Vec2i v){ r->min=v2i_min(r->min,v); r->max=v2i_max(r->max,v); }
-inline void rect2i_include_rect2i(Rect2i* r,const Rect2i* src){ r->min=v2i_min(r->min,src->min);r->max=v2i_max(r->max,src->max); }
-inline Vec2i rect2i_size(const Rect2i* r) { return v2i_sub(r->max,r->min);}
-inline int rect2i_aspect(const Rect2i* r,int precision) { Vec2i sz=rect2i_size(r); return (sz.x*precision)/sz.y;}
-inline Rect2i rect2i_add(const Rect2i* a, Vec2i ofs) { Rect2i ret={v2i_add(a->min,ofs),v2i_add(a->max,ofs)}; return ret;}
-inline int rect2i_area( const Rect2i* r,int denom) { Vec2i sz=rect2i_size(r); return (sz.x*sz.y/denom);}
-inline Rect2i rect2i_intersect( const Rect2i* a,const Rect2i* b ) { Rect2i r; r.min=v2i_max(a->min,b->min); r.max=v2i_min(a->max,b->max); return r;}
-inline int rect2i_overlap( const Rect2i* a,const Rect2i* b) { Rect2i ri=rect2i_intersect(a,b);Vec2i sz= rect2i_size(&ri);if (sz.x>0 && sz.y>0) return sz.x*sz.y; else return 0;}
-inline bool rect2i_contains( const Rect2i* rc, const Vec2i v){ return v.x>=rc->min.x && v.x<rc->max.x && v.y>=rc->min.y && v.y<rc->max.y; }
-inline bool rect2i_valid(const Rect2i* a) { return a->max.x>=a->min.x && a->max.y >= a->min.y; }
-inline void vec2i_print(const Vec2i v) { printf("(%d %d)", v.x,v.y);}
-inline void rect2i_print(const Rect2i* a) { printf("("); vec2i_print(a->min); printf(" "); vec2i_print(a->max); printf(")");}
-inline Vec2i rect2i_centre(const Rect2i* r) { return v2i_avr(r->min,r->max);}
-inline PosSize pos_size_mk(const Vec2i pos, const Vec2i size) { PosSize psz;psz.pos=pos; psz.size=size; return psz;}
-inline PosSize pos_size_from_rect(const Rect2i* r) { PosSize psz;psz.pos=r->min; psz.size=rect2i_size(r); return psz;}
-inline Rect2i rect2i_from_pos_size(const PosSize* psz) { rect2i_mk_at(psz->pos, psz->size);}
-
 //#define SW_POS_SIZE
 typedef struct {
 	Window window;

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -41,6 +41,7 @@ inline Vec2i vec2i_mk(int x, int y) { Vec2i v; v.x=x; v.y=y; return v;}
 inline Vec2i v2i_sub(Vec2i a,Vec2i b) { Vec2i ret= {a.x-b.x,a.y-b.y};return ret; }
 inline Vec2i v2i_add(Vec2i a,Vec2i b) { Vec2i ret= {a.x+b.x,a.y+b.y};return ret; }
 inline Vec2i v2i_mul(Vec2i a,int f,int prec) { Vec2i ret= {(a.x*f)/prec,(a.y*f)/prec};return ret; }
+inline Vec2i v2i_avr(Vec2i a,Vec2i b) { Vec2i ret=v2i_mul(v2i_add(a,b),1,2); return ret;}
 inline Vec2i v2i_mad(Vec2i a,Vec2i b,int f,int prec) { return v2i_add(a, v2i_mul(b,f,prec)); }
 inline Vec2i v2i_lerp(Vec2i a,Vec2i b,int f,int prec) { return v2i_add(a, v2i_mul(v2i_sub(b,a),f,prec)); }
 inline Vec2i v2i_invlerp(const Vec2i vmin,const Vec2i vmax, Vec2i v,int precision ) { Vec2i ret={invlerpi(vmin.x, vmax.x, v.x,precision), invlerpi(vmin.y, vmax.y, v.y,precision)}; return ret; }
@@ -63,7 +64,7 @@ inline int rect2i_overlap( const Rect2i* a,const Rect2i* b) { Rect2i ri=rect2i_i
 inline bool rect2i_valid(const Rect2i* a) { return a->max.x>=a->min.x && a->max.y >= a->min.y; }
 inline void vec2i_print(const Vec2i v) { printf("(%d %d)", v.x,v.y);}
 inline void rect2i_print(const Rect2i* a) { printf("("); vec2i_print(a->min); printf(" "); vec2i_print(a->max); printf(")");}
-inline Vec2i rect2i_centre(const Rect2i* r) { return v2i_lerp(r->min,r->max,1,2);}
+inline Vec2i rect2i_centre(const Rect2i* r) { return v2i_avr(r->min,r->max);}
 inline PosSize pos_size_mk(const Vec2i pos, const Vec2i size) { PosSize psz;psz.pos=pos; psz.size=size; return psz;}
 inline PosSize pos_size_from_rect(const Rect2i* r) { PosSize psz;psz.pos=r->min; psz.size=rect2i_size(r); return psz;}
 inline Rect2i rect2i_from_pos_size(const PosSize* psz) { rect2i_mk_at(psz->pos, psz->size);}
@@ -94,7 +95,6 @@ typedef struct {
 	Pixmap pixmap;
 	Picture origin, destination;
 	Damage damage;
-	float factor;
 	
 	int focused;
 	
@@ -171,4 +171,7 @@ inline int cw_client_height(const ClientWin* w)	{ return sw_size(&w->client).y;}
 inline Vec2i cw_set_tmp_xy(ClientWin* w, int x, int y) { w->x = x; w->y=y;}
 inline Vec2i cw_set_tmp_pos(ClientWin* w, Vec2i pos) { w->x = pos.x; w->y=pos.y;}
 inline Vec2i cw_tmp_pos(ClientWin* w) { return vec2i_mk(w->x,w->y);}
+inline float cw_client_aspect(const ClientWin* w) { Vec2i delta=sw_size(&w->client); return MAX(1,delta.x)/(float)MAX(1,delta.y);}
+inline void cw_set_mini_size( ClientWin* w,Vec2i sz)	{  sw_set_size(&w->mini,sz);}
+
 #endif /* SKIPPY_CLIENT_H */

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -67,6 +67,7 @@ inline Vec2i rect2i_centre(const Rect2i* r) { return v2i_lerp(r->min,r->max,1,2)
 inline PosSize pos_size_mk(const Vec2i pos, const Vec2i size) { PosSize psz;psz.pos=pos; psz.size=size; return psz;}
 inline PosSize pos_size_from_rect(const Rect2i* r) { PosSize psz;psz.pos=r->min; psz.size=rect2i_size(r); return psz;}
 inline Rect2i rect2i_from_pos_size(const PosSize* psz) { rect2i_mk_at(psz->pos, psz->size);}
+
 typedef struct {
 	Window window;
 	int x, y;
@@ -139,4 +140,8 @@ inline Rect2i clientwin_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w
 inline Rect2i clientwin_mini_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w->mini),sw_size(&w->mini));}
 inline Vec2i clientwin_pos(const ClientWin* w)	{ return sw_pos(&w->client);}
 inline Vec2i clientwin_size(const ClientWin* w)	{ return sw_size(&w->client);}
+inline int sw_width(const SkippyWindow* w) { return w->width;} // => w->rect.size.x
+inline int sw_height(const SkippyWindow* w) { return w->height;} // => w->rect.size.y
+inline int sw_x(const SkippyWindow* w) { return w->x;} // => w->rect.pos.x
+inline int sw_y(const SkippyWindow* w) { return w->y;} // => w->rect.pos.y
 #endif /* SKIPPY_CLIENT_H */

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -162,8 +162,10 @@ inline PosSize sw_pos_size(const SkippyWindow* sw)	{ return pos_size_mk(sw_pos(s
 inline void sw_set_pos_size(SkippyWindow* sw, const Vec2i p,const Vec2i sz) { sw_set_pos(sw,p); sw_set_size(sw,sz);}
 
 
-inline Rect2i clientwin_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w->client),sw_size(&w->client));}
-inline Rect2i clientwin_mini_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w->mini),sw_size(&w->mini));}
-inline Vec2i clientwin_pos(const ClientWin* w)	{ return sw_pos(&w->client);}
-inline Vec2i clientwin_size(const ClientWin* w)	{ return sw_size(&w->client);}
+inline Rect2i cw_client_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w->client),sw_size(&w->client));}
+inline Rect2i cw_client_mini_rect(const ClientWin* w)	{ return rect2i_mk_at(sw_pos(&w->mini),sw_size(&w->mini));}
+inline Vec2i cw_client_pos(const ClientWin* w)	{ return sw_pos(&w->client);}
+inline Vec2i cw_client_size(const ClientWin* w)	{ return sw_size(&w->client);}
+inline Vec2i cw_set_xy(ClientWin* w, int x, int y) { w->x = x; w->y=y;}
+inline Vec2i cw_set_pos(ClientWin* w, Vec2i pos) { w->x = pos.x; w->y=pos.y;}
 #endif /* SKIPPY_CLIENT_H */

--- a/src/clientwin.h
+++ b/src/clientwin.h
@@ -32,6 +32,7 @@ typedef struct Rect2i {
 inline int invlerpi(int lo,int hi,int v,int one) { return ((v-lo)*one)/(hi-lo);}
 inline int lerpi(int lo,int hi,int f,int one) { return lo+(((hi-lo)*f)/one);}
 inline void v2i_set(Vec2i* dst, int x, int y) { dst->x=x;dst->y=y;}
+inline Vec2i vec2i_mk(int x, int y) { Vec2i v; v.x=x; v.y=y; return v;}
 inline Vec2i v2i_sub(Vec2i a,Vec2i b) { Vec2i ret= {b.x-a.x,b.y-a.y};return ret; }
 inline Vec2i v2i_add(Vec2i a,Vec2i b) { Vec2i ret= {b.x+a.x,b.y+a.y};return ret; }
 inline Vec2i v2i_mul(Vec2i a,int f,int prec) { Vec2i ret= {(a.x*f)/prec,(a.y*f)/prec};return ret; }
@@ -43,6 +44,8 @@ inline Vec2i rect2i_invlerp(const Rect2i* r, Vec2i v, int precision) { return v2
 inline Vec2i v2i_min(Vec2i a,Vec2i b) { Vec2i ret={MIN(a.x,b.x),MIN(a.y,b.y)}; return ret;}
 inline Vec2i v2i_max(Vec2i a,Vec2i b) { Vec2i ret={MAX(a.x,b.x),MAX(a.y,b.y)}; return ret;}
 inline Rect2i rect2i_init(void){ Rect2i ret={{INT_MAX,INT_MAX},{-INT_MAX,-INT_MAX}}; return ret;}
+inline Rect2i rect2i_mk_at(Vec2i pos, Vec2i size){ Rect2i ret; ret.min=pos; ret.max=v2i_add(pos,size);  return ret;}
+inline Rect2i rect2i_mk(Vec2i a, Vec2i b){ Rect2i ret; ret.min=a; ret.max=b;  return ret;}
 inline void rect2i_set_init(Rect2i* ret){  v2i_set(&ret->min,INT_MAX,INT_MAX);v2i_set(&ret->max,-INT_MAX,-INT_MAX); }
 inline void rect2i_include(Rect2i* r,Vec2i v){ r->min=v2i_min(r->min,v);r->max=v2i_max(r->max,v); }
 inline void rect2i_include_rect2i(Rect2i* r,const Rect2i* src){ r->min=v2i_min(r->min,src->min);r->max=v2i_max(r->max,src->max); }
@@ -106,5 +109,10 @@ int clientwin_check_group_leader_func(dlist *l, void *data);
 void clientwin_render(ClientWin *);
 void clientwin_schedule_repair(ClientWin *cw, XRectangle *area);
 void clientwin_repair(ClientWin *cw);
+// accessors, less needed if code is refactored to use vec2i etc.
+inline Vec2i skippywindow_pos(const SkippyWindow* w)	{ vec2i_mk(w->x,w->y); }
+inline Vec2i skippywindow_size(const SkippyWindow* w)	{ vec2i_mk(w->width,w->height); }
+inline Rect2i clientwin_rect(const ClientWin* w)	{ return rect2i_mk_at(skippywindow_pos(&w->client),skippywindow_size(&w->client));}
+inline Rect2i clientwin_mini_rect(const ClientWin* w)	{ return rect2i_mk_at(skippywindow_pos(&w->mini),skippywindow_size(&w->mini));}
 
 #endif /* SKIPPY_CLIENT_H */

--- a/src/config.h
+++ b/src/config.h
@@ -131,5 +131,44 @@ config_get_double_wrap(dlist *config, const char *section, const char *key,
 	*tgt = config_get_double(config, section, key, *tgt, min, max);
 }
 
+/**
+ * @brief Get a float value from configuration.
+ */
+static inline float
+config_get_float(dlist *config, const char *section, const char *key,
+		float def, float min, float max) {
+	const char *result = config_get(config, section, key, NULL);
+	if (!result)
+		return def;
+	char *endptr = NULL;
+	float fresult = strtof(result, &endptr);
+	if (!endptr || (*endptr && !isspace(*endptr))) {
+		printfef("(%s, %s, %f): Value \"%s\" is not a valid floating-point number.",
+			section, key, def, result);
+		return def;
+	}
+	if (fresult > max) {
+		printfef("(%s, %s, %f): Value \"%s\" larger than maximum value %f.",
+			section, key, def, result, max);
+		return max;
+	}
+	if (fresult < min) {
+		printfef("(%s, %s, %f): Value \"%s\" smaller than minimal value %f.",
+			section, key, def, result, min);
+		return min;
+	}
+	return fresult;
+}
+
+/**
+ * @brief Wrapper of config_get_float().
+ */
+static inline void
+config_get_float_wrap(dlist *config, const char *section, const char *key,
+		float *tgt, float min, float max) {
+	*tgt = config_get_float(config, section, key, *tgt, min, max);
+}
+
+
 #endif /* SKIPPY_CONFIG_H */
 

--- a/src/dlist.h
+++ b/src/dlist.h
@@ -91,4 +91,9 @@ void dlist_swap(dlist *, dlist *);
 typedef int (*dlist_cmp_func)(dlist *, dlist *, void *);
 void dlist_sort(dlist *, dlist_cmp_func, void *);
 
+/* Iteration helper macro */
+#define DLIST_FOREACH(TYPE,ITER_PTR,IN_LIST) for (dlist* iter=IN_LIST; iter;iter=iter->next){ TYPE* ITER_PTR=(TYPE*)(iter->data);
+#define DLIST_NEXT }
+
+
 #endif /* SKIPPY_DLIST_H */

--- a/src/layout.c
+++ b/src/layout.c
@@ -162,7 +162,7 @@ float layout_factor(const MainWin *mw,Vec2i size, unsigned int extra_border) {
 
 	float factor = (float)(mw_width(mw) - extra_border) / size.x;
 	if(factor * size.y > mw_height(mw) - extra_border)
-		factor = (float)(mw_width(mw) - extra_border) / size.y;
+		factor = (float)(mw_height(mw) - extra_border) / size.y;
 	return factor;
 }
 void layout_run_scale_all(const MainWin *mw, dlist *windows, Vec2i total_size)

--- a/src/layout.c
+++ b/src/layout.c
@@ -255,7 +255,7 @@ void layout_grid(int separation, Vec2i size, dlist* windows) {
 	float av_aspect = sum_aspect/(float) num;
 
 	//printf("rowum=%.3f %.3f %.3f\n",(num*win_aspect)/av_aspect, av_aspect,win_aspect);
-	int num_rows = MAX(1,sqrt((num*win_aspect)/ av_aspect  ));
+	int num_rows = MAX(1,sqrt((num/win_aspect)* av_aspect  ));
 	int num_cols = (num+(num_rows-1))/num_rows;// todo: per row, for last one..
 	
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -22,6 +22,7 @@
 void
 layout_run(MainWin *mw, dlist *windows, unsigned int *total_width, unsigned int *total_height)
 {
+	mw->distance=8;
 	int sum_w = 0, max_h = 0, max_w = 0, max_row_w = 0;
 	int row_y = 0, y = 0, x = 0, row_h = 0;
 	
@@ -38,6 +39,7 @@ layout_run(MainWin *mw, dlist *windows, unsigned int *total_width, unsigned int 
 		sum_w += cw->client.width;
 		max_w = MAX(max_w, cw->client.width);
 		max_h = MAX(max_h, cw->client.height);
+		logd("win %d,%d %dx%d\n ",  cw->client.x,cw->client.y, cw->client.width, cw->client.height);
 	}
 	
 	for(iter = windows; iter; iter = iter->next)

--- a/src/layout.c
+++ b/src/layout.c
@@ -54,24 +54,15 @@ layout_run_desktop(MainWin *mw, dlist *windows, unsigned int *total_width, unsig
 	windows_get_rect2i(&rect_all ,windows);
 	for (iter=windows; iter; iter=iter->next) {
 		ClientWin* cw=(ClientWin*) iter->data;
-		//printf("%d %d %d %d\n",cw->client.x,cw->client.y,cw->client.width,cw->client.height);
-		//Vec2i vp=clientwin_pos(&cw->client);
-		//vec2i_print(vp);
-		//rect2i_print(&cwr);
-//		cw->x = cw->client.x-rect_all.min.x; cw->y=cw->client.y-rect_all.min.y;
 
 		cw->x = cw->client.x-rect_all.min.x;
 		cw->y = cw->client.y- rect_all.min.y;
-//		cw->x=rect_all.min.x; cw->y=0;
 	}
 	Vec2i size_all=rect2i_size(&rect_all);
-	printf("total bounds:-");
-	rect2i_print(&rect_all);
-	printf("\n");
-	vec2i_print(size_all);
+
 
 	*total_width=size_all.x; *total_height=size_all.y;
-	layout_dump(windows,total_width,total_height);
+	//layout_dump(windows,total_width,total_height);
 
 
 }
@@ -97,7 +88,7 @@ layout_run_original(MainWin *mw, dlist *windows, unsigned int *total_width, unsi
 		sum_w += cw->client.width;
 		max_w = MAX(max_w, cw->client.width);
 		max_h = MAX(max_h, cw->client.height);
-		logd("win %d,%d %dx%d\n ",  cw->client.x,cw->client.y, cw->client.width, cw->client.height);
+		//logd("win %d,%d %dx%d\n ",  cw->client.x,cw->client.y, cw->client.width, cw->client.height);
 	}
 	
 	for(iter = windows; iter; iter = iter->next)
@@ -162,7 +153,7 @@ layout_run_original(MainWin *mw, dlist *windows, unsigned int *total_width, unsi
 		dlist_free(row);
 	}
 
-	layout_dump(windows,total_width,total_height);
+	//layout_dump(windows,total_width,total_height);
 
 	layout_run_scale_all(mw,windows,*total_width,*total_height);
 	
@@ -198,7 +189,8 @@ void layout_run_scale_all(MainWin *mw, dlist *windows, unsigned int total_width,
 
 		cw->mini.width = MAX(1, (int)cw->client.width * factor);
 		cw->mini.height = MAX(1, (int)cw->client.height * factor);
-		printf("%d %d %d %d\n",cw->mini.x,cw->mini.y, cw->mini.width,cw->mini.height);
+
+		//printf("%d %d %d %d\n",cw->mini.x,cw->mini.y, cw->mini.width,cw->mini.height);
 	}
 }
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -26,7 +26,7 @@ layout_dump(const dlist* windows,Vec2i total_size) {
 	const dlist* iter;
 	for(iter = windows; iter; iter = iter->next){
 		const ClientWin *cw = (const ClientWin*)iter->data;
-		printf("mini pos:%d %d / %d %d\n",cw->x,cw->y,total_size.x, total_size.y);
+		printf("mini pos:%d,%d size= %d,%d/ %d %d\n",cw->x,cw->y,cw->mini.width,cw->mini.height, total_size.x, total_size.y);
 	}
 
 }
@@ -41,6 +41,7 @@ windows_get_rect2i(Rect2i* ret,const dlist* windows) {
 		rect2i_include_rect2i(ret, &cwr);
 	}
 }
+
 
 
 void
@@ -62,15 +63,17 @@ layout_run_desktop(MainWin *mw, dlist *windows, Vec2i* total_size)
 
 	*total_size=size_all;
 	//layout_dump(windows,total_width,total_height);
+	layout_run_scale_all(mw, windows, *total_size);
 
 
 }
 
-
+// Skippy Original layout - Slot-together into rows adaptively
+//
 void
-layout_run_original(MainWin *mw, dlist *windows, Vec2i* total_size)
+layout_run_original(int separation, dlist *windows, Vec2i* total_size)
 {
-	mw->distance=8;
+//	mw->distance=8;
 	int sum_w = 0, max_row_w = 0;
 	int row_y = 0, y = 0, x = 0, row_h = 0;
 	Vec2i max_win_size=vec2i_mk(0,0);
@@ -96,9 +99,9 @@ layout_run_original(MainWin *mw, dlist *windows, Vec2i* total_size)
 		for(; slot_iter; slot_iter = slot_iter->next)
 		{
 			dlist *slot = (dlist *)slot_iter->data;
-			int slot_h = -mw->distance;
-			REDUCE(slot_h = slot_h + ((ClientWin*)iter->data)->client.height + mw->distance, slot);
-			if(slot_h + mw->distance + cw->client.height < max_win_size.y)
+			int slot_h = -separation;
+			REDUCE(slot_h = slot_h + ((ClientWin*)iter->data)->client.height + separation, slot);
+			if(slot_h + separation + cw->client.height < max_win_size.y)
 			{
 				slot_iter->data = dlist_add(slot, cw);
 				break;
@@ -119,12 +122,12 @@ layout_run_original(MainWin *mw, dlist *windows, Vec2i* total_size)
 		{
 			ClientWin *cw = (ClientWin *)iter->data;
 			cw_set_tmp_xy(cw,x + (slot_w - cw->client.width) / 2,y);
-			y += cw_client_height(cw) + mw->distance;
+			y += cw_client_height(cw) + separation;
 			rows->data = dlist_add((dlist *)rows->data, cw);
 		}
 		row_h = MAX(row_h, y - row_y);
 		total_size->y = MAX(total_size->y, y);
-		x += slot_w + mw->distance;
+		x += slot_w + separation;
 		total_size->x = MAX(total_size->x, x);
 		if(x > max_row_w)
 		{
@@ -139,7 +142,7 @@ layout_run_original(MainWin *mw, dlist *windows, Vec2i* total_size)
 	
 	//*total_width -= mw->distance;
 	//*total_height -= mw->distance;
-	*total_size=v2i_sub(*total_size, vec2i_mk(mw->distance,mw->distance));
+	*total_size=v2i_sub(*total_size, vec2i_mk(separation,separation));
 	
 	for(iter = dlist_first(rows); iter; iter = iter->next)
 	{
@@ -153,9 +156,83 @@ layout_run_original(MainWin *mw, dlist *windows, Vec2i* total_size)
 
 	//layout_dump(windows,total_width,total_height);
 
-	layout_run_scale_all(mw,windows,*total_size);
+	//layout_run_scale_all(mw,windows,*total_size);
 	
 	dlist_free(rows);
+}
+
+// simple grid layout
+
+#define DLIST_ITER_BEGIN(list, type, ptr) for (dlist* iter=list; iter;iter=iter->next){ type* ptr=(type*)(iter->data);
+#define DLIST_ITER_END }
+
+void layout_run_grid(int separation, Vec2i size, dlist* windows) {
+	int num= dlist_len(windows);
+	if (!num) return;
+	int denom=1<<12;
+	// get min,max aspect ratios. if the windows are all landscape or portrait it changes numx/numy
+	float min_aspect=100000.0f,max_aspect=0.f;
+	float sum_aspect=0.f;
+	DLIST_ITER_BEGIN(windows, ClientWin, cw)
+		float aspect=cw_client_aspect(cw);
+		min_aspect=MIN(min_aspect,aspect); max_aspect=MAX(max_aspect,aspect);	
+		sum_aspect+=aspect;
+	DLIST_ITER_END	
+	float win_aspect=(float)size.x/(float)size.y;
+	float av_aspect = sum_aspect/(float) num;
+
+//	int num_cols = MAX(1,sqrt(num *win_aspect/av_aspect  ));
+//	int num_rows = (num+(num_cols-1))/num_cols;// todo: per row, for last one..
+	printf("rowum=%.3f %.3f %.3f\n",(num*win_aspect)/av_aspect, av_aspect,win_aspect);
+	int num_rows = MAX(1,sqrt((num*win_aspect)/ av_aspect  ));
+	int num_cols = (num+(num_rows-1))/num_rows;// todo: per row, for last one..
+	
+
+// rows*cols = num
+	printf("%.3f num=%d rows=%d cols=%d \n",av_aspect, num,num_rows,num_cols);
+	
+	// todo: placement for minimum movement.
+	int	row=0,col=0;
+	Vec2i pos=vec2i_mk(0,0);
+	DLIST_ITER_BEGIN(windows, ClientWin, cw)
+		// create grid cell to hold the window
+//		Vec2i cell_min=vec2i_(size.x*denom/ num_cols, size.y*denom / num_rows);
+		Rect2i cell=rect2i_mk(
+			vec2i_mk((col*size.x)/num_cols,(row*size.y)/num_rows),
+			vec2i_mk(((col+1)*size.x)/num_cols,((row+1)*size.y)/num_rows));
+
+		Vec2i cell_size=//rect2i_size(&cell);
+			v2i_sub(cell.max,cell.min);
+		float client_aspect=cw_client_aspect(cw);
+		float cell_aspect=cell_size.x/(float)cell_size.y;
+		Vec2i mini_size;
+		printf("%.3f\n",client_aspect);
+		float f=client_aspect/cell_aspect;
+		if (f>1.0) {
+			
+			mini_size.x=cell_size.x ;
+			mini_size.y=(cell_size.y/f);
+		} else {
+			mini_size.x=(cell_size.x*f);
+			mini_size.y=cell_size.y;
+		}
+		//mini_size=v2i_sub(cell_size,vec2i_mk(separation,separation));
+		//mini_size=v2i_mul(mini_size,1,2);
+		cw_set_mini_size(cw,mini_size);
+//		cw->factor = 0.5f*mini_size.x/(float)cw_client_size(cw).x;
+		
+//		cw_set_tmp_pos(cw, v2i_sub(rect2i_centre(&cell), v2i_mul(mini_size,-1,2)));
+		cw_set_tmp_pos(cw, v2i_mad(rect2i_centre(&cell),mini_size,-1,2));
+		cw->mini.x=cw->x; cw->mini.y=cw->y;
+		col++; 
+		if (col>=num_cols) {
+			col=0; row++; 
+		}
+		// todo: size per row.
+	DLIST_ITER_END
+
+	layout_dump(windows,size);
+
 }
 
 float layout_factor(const MainWin *mw,Vec2i size, unsigned int extra_border) {
@@ -179,7 +256,7 @@ void layout_run_scale_all(const MainWin *mw, dlist *windows, Vec2i total_size)
 	{
 		ClientWin *cw = (ClientWin*)iter->data;
 
-		cw->factor=factor;
+//		cw->factor=factor;
 
 		sw_set_pos_size(&cw->mini,
 				v2i_mad(delta, cw_tmp_pos(cw), ifactor,denom),
@@ -195,9 +272,14 @@ layout_run(MainWin *mw,LAYOUT_MODE mode, dlist *windows, Vec2i* total_size)
 {
 	if (mode==LAYOUT_DESKTOP){ 
 		layout_run_desktop(mw,windows,total_size);
-	} else
-		layout_run_original(mw,windows,total_size);
+		layout_run_scale_all(mw, windows, *total_size);
+	} else if (mode==LAYOUT_GRID) {
+		layout_run_grid(mw->distance, mw_size(mw),windows);
+		*total_size=mw_size(mw);
+	} else {
+		layout_run_original(mw->distance,windows,total_size);
+		layout_run_scale_all(mw, windows, *total_size);
+	}
 
-	layout_run_scale_all(mw, windows, *total_size);
 }
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -55,8 +55,10 @@ layout_run_desktop(MainWin *mw, dlist *windows, unsigned int *total_width, unsig
 	for (iter=windows; iter; iter=iter->next) {
 		ClientWin* cw=(ClientWin*) iter->data;
 
-		cw->x = cw->client.x-rect_all.min.x;
-		cw->y = cw->client.y- rect_all.min.y;
+		Vec2i ofs = vec2i_sub(sw_pos(&cw->client), rect_all.min));
+		cw_set_xy(ofs);
+//		cw->x = cw->client.x-rect_all.min.x;
+//		cw->y = cw->client.y- rect_all.min.y;
 	}
 	Vec2i size_all=rect2i_size(&rect_all);
 

--- a/src/layout.c
+++ b/src/layout.c
@@ -245,23 +245,41 @@ void layout_grid(int separation, Vec2i size, dlist* windows) {
 	// get min,max aspect ratios. if the windows are all landscape or portrait it changes numx/numy
 	float min_aspect=100000.0f,max_aspect=0.f;
 	float sum_aspect=0.f;
-	
+	float total_area=0.f;
 	DLIST_FOREACH(ClientWin, cw,/*IN*/ windows )
 		float aspect=cw_client_aspect(cw);
 		min_aspect=MIN(min_aspect,aspect); max_aspect=MAX(max_aspect,aspect);	
-		sum_aspect+=aspect;
+		Vec2i wsize=cw_client_size(cw);
+		float area=wsize.x*wsize.y;
+		total_area += area;
+		sum_aspect+=aspect;//*area;
 	DLIST_NEXT
 	float win_aspect=(float)size.x/(float)size.y;
-	float av_aspect = sum_aspect/(float) num;
+	float av_aspect = sum_aspect/(float)num;// total_area;
 
-	//printf("rowum=%.3f %.3f %.3f\n",(num*win_aspect)/av_aspect, av_aspect,win_aspect);
-	int num_rows = MAX(1,sqrt((num/win_aspect)* av_aspect  ));
+	printf("row0=%.3f row1=%.3f row2=%.3f avasp%.3f main_asp%.3f\n",
+		sqrt((num*win_aspect)/av_aspect),
+		sqrt((num*av_aspect)/win_aspect),
+		sqrt(num)*(av_aspect/win_aspect),
+		av_aspect,
+		win_aspect);
+//	int num_rows = MAX(1,sqrt((num/win_aspect)*	 av_aspect  ));
+	//printf("aspect=");
+//	av_aspect=1.0f;
+	float d=sqrt(num*(av_aspect/win_aspect)) ;
+	int num_rows = MAX(1,d+0.5f);
 	int num_cols = (num+(num_rows-1))/num_rows;// todo: per row, for last one..
 	
 
-	//printf("%.3f num=%d rows=%d cols=%d \n",av_aspect, num,num_rows,num_cols);
+	printf("%.3f d=%.3f num=%d rows=%d cols=%d \n",av_aspect,d, num,num_rows,num_cols);
 
 	
+	printf("row0=%.3f row1=%.3f row2=%.3f avasp%.3f main_asp%.3f\n",
+		sqrt((num*win_aspect)/av_aspect),
+		sqrt((num*av_aspect)/win_aspect),
+		sqrt(num)*(av_aspect/win_aspect),
+		av_aspect,
+		win_aspect);
 
 	// TODO Sort horizontally. 	
 	// todo: pick major axis. widescreen monitor, its usually horiz, but we might be placing in subwindows.

--- a/src/layout.c
+++ b/src/layout.c
@@ -209,7 +209,7 @@ void layout_run_grid(int separation, Vec2i size, dlist* windows) {
 		}
 		cw_set_mini_size(cw,mini_size);
 
-		cw_set_tmp_pos(cw, v2i_mad(rect2i_centre(&cell),mini_size,-1,2));
+		cw_set_tmp_pos(cw, v2i_sub(rect2i_centre(&cell),v2i_half(mini_size)));
 		cw->mini.x=cw->x; cw->mini.y=cw->y;
 		col++; 
 		if (col>=num_cols) {

--- a/src/layout.c
+++ b/src/layout.c
@@ -318,6 +318,8 @@ void layout_run_scale_all(const MainWin *mw, dlist *windows, Vec2i total_size)
 	}
 }
 
+// TODO - layout which biases desktop sizes according to recent use.
+// or grid mode including desktops placed as individual windows similar to gnomeshell
 
 void
 layout_run(MainWin *mw,LAYOUT_MODE mode, dlist *windows, Vec2i* total_size) 

--- a/src/layout.h
+++ b/src/layout.h
@@ -20,6 +20,15 @@
 #ifndef SKIPPY_LAYOUT_H
 #define SKIPPY_LAYOUT_H
 
-void layout_run(MainWin *, dlist *, unsigned int *, unsigned int *);
+typedef enum LAYOUT_MODE {
+	LAYOUT_ORIGINAL,
+	LAYOUT_DESKTOP,
+	LAYOUT_GRID
+}
+LAYOUT_MODE;
+
+void layout_run(MainWin *, LAYOUT_MODE m, dlist *, unsigned int *, unsigned int *);
+float layout_factor(const MainWin*,unsigned int width,unsigned int height, unsigned int extra_border);
+
 
 #endif /* SKIPPY_LAYOUT_H */

--- a/src/layout.h
+++ b/src/layout.h
@@ -27,8 +27,8 @@ typedef enum LAYOUT_MODE {
 }
 LAYOUT_MODE;
 
-void layout_run(MainWin *, LAYOUT_MODE m, dlist *, unsigned int *, unsigned int *);
-float layout_factor(const MainWin*,unsigned int width,unsigned int height, unsigned int extra_border);
+void layout_run(MainWin *, LAYOUT_MODE m, dlist *, Vec2i* total_size);
+float layout_factor(const MainWin*,Vec2i size, unsigned int extra_border);
 
 
 #endif /* SKIPPY_LAYOUT_H */

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -288,8 +288,7 @@ mainwin_map(MainWin *mw) {
 	XRaiseWindow(ps->dpy, mw->window);
 
 	// Might because of WM reparent, XSetInput() doesn't work here
-	XSetInputFocus(ps->dpy, mw->window, RevertToParent, CurrentTime);
-	XGrabKeyboard(ps->dpy, mw->window, True, GrabModeAsync, GrabModeAsync,
+	XSetInputFocus(ps->dpy, mw->window, RevertToParent, CurrentTime);	XGrabKeyboard(ps->dpy, mw->window, True, GrabModeAsync, GrabModeAsync,
 			CurrentTime);
 }
 

--- a/src/mainwin.c
+++ b/src/mainwin.c
@@ -96,6 +96,8 @@ mainwin_create(session_t *ps) {
 	mw->key_l = XKeysymToKeycode(dpy, XK_l);
 	mw->key_enter = XKeysymToKeycode(dpy, XK_Return);
 	mw->key_space = XKeysymToKeycode(dpy, XK_space);
+	mw->key_page_up = XKeysymToKeycode(dpy, XK_Page_Up);
+	mw->key_page_down = XKeysymToKeycode(dpy, XK_Page_Down);
 	mw->key_escape = XKeysymToKeycode(dpy, XK_Escape);
 	mw->key_q = XKeysymToKeycode(dpy, XK_q);
 	

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -70,5 +70,8 @@ int mainwin_handle(MainWin *, XEvent *);
 void mainwin_update_background(MainWin *mw);
 void mainwin_update(MainWin *mw);
 void mainwin_transform(MainWin *mw, float f);
+inline  Vec2i mainwin_pos(const MainWin* mw) 	{ vec2i_mk( mw->x,mw->y);}
+inline  Vec2i mainwin_size(const MainWin* mw) 	{ vec2i_mk( mw->width,mw->height);}
+inline  Rect2i mainwin_rect(const MainWin* mw) 	{ rect2i_mk_at( mainwin_pos(mw), mainwin_size(mw) );}
 
 #endif /* SKIPPY_MAINWIN_H */

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -55,7 +55,7 @@ struct _MainWin
 	
 	KeyCode key_act, key_up, key_down, key_left, key_right,
 		key_h, key_j, key_k, key_l,
-		key_enter, key_space, key_q, key_escape;
+		key_enter, key_space, key_q, key_escape,key_page_up,key_page_down;
 	
 #ifdef CFG_XINERAMA
 	int xin_screens;

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -73,6 +73,8 @@ struct _MainWin
 #define mw_min(mw) ((mw)->rect.pos)
 #define mw_max(mw) (v2i_add((mw)->rect.pos,(mw)->rect.size))
 #define mw_rect(mw) (rect2i_mk_at(mw_pos(mw),mw_size(mw)))
+#define mw_width(mw) (mw_size(mw).x)
+#define mw_height(mw) (mw_size(mw).y)
 
 typedef struct _MainWin MainWin;
 

--- a/src/mainwin.h
+++ b/src/mainwin.h
@@ -39,7 +39,9 @@ struct _MainWin
 	Picture background;
 	Pixmap bg_pixmap;
 	int x, y;
-	unsigned int width, height, distance;
+	unsigned int width, height;
+	//PosSize	rect;
+	unsigned int distance;
 	XRenderPictFormat *format;
 	XTransform transform;
 	
@@ -60,6 +62,18 @@ struct _MainWin
 	XineramaScreenInfo *xin_info, *xin_active;
 #endif /* CFG_XINERAMA */
 };
+#ifdef MW_POS_SIZE
+#define mw_pos(mw) ((mw)->rect.pos)
+#define mw_size(mw) ((mw)->rect.max)
+#define mw_max(mw) (vec2i_add(mw_pos(mw),mw_size(mw)))
+#else
+#define mw_pos(mw) (vec2i_mk((mw)->x,(mw)->y))
+#define mw_size(mw) (vec2i_mk((mw)->width,(mw)->height))
+#endif
+#define mw_min(mw) ((mw)->rect.pos)
+#define mw_max(mw) (v2i_add((mw)->rect.pos,(mw)->rect.size))
+#define mw_rect(mw) (rect2i_mk_at(mw_pos(mw),mw_size(mw)))
+
 typedef struct _MainWin MainWin;
 
 MainWin *mainwin_create(session_t *ps);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -129,7 +129,6 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader)
 
 	CARD32 desktop = wm_get_current_desktop(ps->dpy);
 	unsigned int width, height;
-	float factor;
 	int xoff, yoff;
 	dlist *iter, *tmp;
 	
@@ -153,16 +152,18 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader)
 	dlist_sort(mw->cod, clientwin_sort_func, 0);
 	
 	/* Move the mini windows around */
-	layout_run(mw, mw->cod, &width, &height);
-	factor = (float)(mw->width - 100) / width;
-	if(factor * height > mw->height - 100)
-		factor = (float)(mw->height - 100) / height;
+	layout_run(mw, LAYOUT_DESKTOP, mw->cod, &width, &height);
+	int extra_border=mw->distance;
+//	float factor=layout_factor(mw,width,height,mw->distance);
+	float factor = (float)(mw->width - extra_border) / width;
+	if(factor * height > mw->height - extra_border)
+		factor = (float)(mw->height - extra_border) / height;
 	
 	xoff = (mw->width - (float)width * factor) / 2;
 	yoff = (mw->height - (float)height * factor) / 2;
 	mainwin_transform(mw, factor);
 	for(iter = mw->cod; iter; iter = iter->next)
-		clientwin_move((ClientWin*)iter->data, factor, xoff, yoff);
+		clientwin_create_scaled_image((ClientWin*)iter->data /*, factor, xoff, yoff*/);
 	
 	/* Get the currently focused window and select which mini-window to focus */
 	iter = dlist_find(mw->cod, clientwin_cmp_func, (void *)focus);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -115,7 +115,7 @@ update_clients(MainWin *mw, dlist *clients, Bool *touched)
 		}
 	}
 
-	printf("update clients: %d active\n ", dlist_len(clients));
+	logd("update clients: %d active\n ", dlist_len(clients));
 	
 	dlist_free(stack);
 	
@@ -140,7 +140,7 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader)
 		dlist_free(mw->cod);
 	
 	tmp = dlist_first(dlist_find_all(clients, (dlist_match_func)clientwin_validate_func, &desktop));
-	printf("clients:%d,valid:%d\n",dlist_len(clients),dlist_len(tmp));
+	logd("clients:%d,valid:%d\n",dlist_len(clients),dlist_len(tmp));
 	if(leader != None)
 	{
 		mw->cod = dlist_first(dlist_find_all(tmp, clientwin_check_group_leader_func, (void*)&leader));

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -114,6 +114,8 @@ update_clients(MainWin *mw, dlist *clients, Bool *touched)
 				*touched = True;
 		}
 	}
+
+	printf("update clients: %d active\n ", dlist_len(clients));
 	
 	dlist_free(stack);
 	
@@ -138,13 +140,13 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader)
 		dlist_free(mw->cod);
 	
 	tmp = dlist_first(dlist_find_all(clients, (dlist_match_func)clientwin_validate_func, &desktop));
+	printf("clients:%d,valid:%d\n",dlist_len(clients),dlist_len(tmp));
 	if(leader != None)
 	{
 		mw->cod = dlist_first(dlist_find_all(tmp, clientwin_check_group_leader_func, (void*)&leader));
 		dlist_free(tmp);
 	} else
 		mw->cod = tmp;
-	
 	if(! mw->cod)
 		return clients;
 	
@@ -530,6 +532,7 @@ void show_help()
 			"\t--activate-window-picker  - tells the daemon to show the window picker.\n"
 			"\t--help                    - show this message.\n"
 			"\t-S                        - Synchronize X operation (debugging).\n"
+			"\t-a                        - show windows from all desktops.\n"
 			, stdout);
 }
 
@@ -646,13 +649,17 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 		OPT_DM_START,
 		OPT_DM_STOP,
 	};
-	static const char * opts_short = "hS";
+	static const char * opts_short = "hSa";
 	static const struct option opts_long[] = {
-		{ "help",					no_argument,	NULL, 'h' },
-		{ "config",					required_argument, NULL, OPT_CONFIG },
-		{ "activate-window-picker", no_argument,	NULL, OPT_ACTV_PICKER },
-		{ "start-daemon",			no_argument,	NULL, OPT_DM_START },
-		{ "stop-daemon",			no_argument,	NULL, OPT_DM_STOP },
+		{ "help",					no_argument,	NULL, 'h'},
+		{ "config",					required_argument, NULL, OPT_CONFIG},
+		{ "activate-window-picker", no_argument,	NULL, OPT_ACTV_PICKER},
+		{ "start-daemon",			no_argument,	NULL, OPT_DM_START},
+		{ "stop-daemon",			no_argument,	NULL, OPT_DM_STOP},
+		{ "all desktops",			no_argument,	NULL, 'a'},
+//		{ "keep layout",			no_argument,	NULL, 'k' },
+//		{ "grid layout",			no_argument,	NULL, 'g' },
+//		{ "smart layout",			no_argument,	NULL, 's' },
 		{ NULL, no_argument, NULL, 0 }
 	};
 
@@ -666,6 +673,9 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 				case OPT_CONFIG:
 					ps->o.config_path = mstrdup(optarg);
 					break;
+//				case 'k':	ps->keep_layout=1; break;
+//				case 'g':	ps->grid_layout=1; break;
+//				case 's':	ps->smart_layout=1; break;
 				case '?':
 				case 'h':
 					show_help();
@@ -683,6 +693,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 			case OPT_CONFIG: break;
 #define T_CASEBOOL(idx, option) case idx: ps->o.option = true; break
 			T_CASEBOOL('S', synchronize);
+			T_CASEBOOL('a',	xinerama_showAll);
 			case OPT_ACTV_PICKER:
 				ps->o.mode = PROGMODE_ACTV_PICKER;
 				break;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -121,10 +121,10 @@ update_clients(MainWin *mw, dlist *clients, Bool *touched)
 	
 	return clients;
 }
+
 static LAYOUT_MODE
-get_layout_mode(const ps = mw->ps) {
-	session_t * const ps = mw->ps;
-	if (ps->layout_grid) { 
+get_layout_mode(const session_t* ps) {
+	if (ps->o.layout_desktop) { 
 		return LAYOUT_DESKTOP;
 	}
 	else {
@@ -545,6 +545,7 @@ void show_help()
 			"\t--help                    - show this message.\n"
 			"\t-S                        - Synchronize X operation (debugging).\n"
 			"\t-a                        - show windows from all desktops.\n"
+			"\t-d                        - 'expo' style Desktop layout .\n"
 			, stdout);
 }
 

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -121,6 +121,16 @@ update_clients(MainWin *mw, dlist *clients, Bool *touched)
 	
 	return clients;
 }
+static LAYOUT_MODE
+get_layout_mode(const ps = mw->ps) {
+	session_t * const ps = mw->ps;
+	if (ps->layout_grid) { 
+		return LAYOUT_DESKTOP;
+	}
+	else {
+		return LAYOUT_ORIGINAL;
+	}
+}
 
 static dlist *
 do_layout(MainWin *mw, dlist *clients, Window focus, Window leader)
@@ -152,7 +162,8 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader)
 	dlist_sort(mw->cod, clientwin_sort_func, 0);
 	
 	/* Move the mini windows around */
-	layout_run(mw, LAYOUT_DESKTOP, mw->cod, &width, &height);
+	LAYOUT_MODE mode=get_layout_mode(ps);
+	layout_run(mw, mode, mw->cod, &width, &height);
 	int extra_border=mw->distance;
 //	float factor=layout_factor(mw,width,height,mw->distance);
 	float factor = (float)(mw->width - extra_border) / width;
@@ -650,7 +661,7 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 		OPT_DM_START,
 		OPT_DM_STOP,
 	};
-	static const char * opts_short = "hSa";
+	static const char * opts_short = "hSagds";
 	static const struct option opts_long[] = {
 		{ "help",					no_argument,	NULL, 'h'},
 		{ "config",					required_argument, NULL, OPT_CONFIG},
@@ -674,9 +685,6 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 				case OPT_CONFIG:
 					ps->o.config_path = mstrdup(optarg);
 					break;
-//				case 'k':	ps->keep_layout=1; break;
-//				case 'g':	ps->grid_layout=1; break;
-//				case 's':	ps->smart_layout=1; break;
 				case '?':
 				case 'h':
 					show_help();
@@ -695,6 +703,9 @@ parse_args(session_t *ps, int argc, char **argv, bool first_pass) {
 #define T_CASEBOOL(idx, option) case idx: ps->o.option = true; break
 			T_CASEBOOL('S', synchronize);
 			T_CASEBOOL('a',	xinerama_showAll);
+			T_CASEBOOL('d',	layout_desktop);
+			T_CASEBOOL('s',	layout_smart);
+			T_CASEBOOL('g',	layout_grid);
 			case OPT_ACTV_PICKER:
 				ps->o.mode = PROGMODE_ACTV_PICKER;
 				break;

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -163,19 +163,20 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader,float t)
 	
 	/* Move the mini windows around */
 	LAYOUT_MODE mode=get_layout_mode(ps);
-	layout_run(mw, mode, mw->cod, &width, &height);
+	Vec2i total_size;
+	layout_run(mw, mode, mw->cod, &total_size);
 	int extra_border=mw->distance;
 //	float factor=layout_factor(mw,width,height,mw->distance);
 	for(iter = mw->cod; iter; iter = iter->next)
 		clientwin_lerp_client_to_mini((ClientWin*)iter->data,t);
 
 
-	float factor = (float)(mw->width - extra_border) / width;
+	float factor = (float)(mw->width - extra_border) / total_size.x;
 	if(factor * height > mw->height - extra_border)
-		factor = (float)(mw->height - extra_border) / height;
+		factor = (float)(mw->height - extra_border) / total_size.y;
 	
-	xoff = (mw->width - (float)width * factor) / 2;
-	yoff = (mw->height - (float)height * factor) / 2;
+	xoff = (mw->width - (float)total_size.x * factor) / 2;
+	yoff = (mw->height - (float)total_size.y * factor) / 2;
 	mainwin_transform(mw, factor);
 	for(iter = mw->cod; iter; iter = iter->next)
 		clientwin_create_scaled_image((ClientWin*)iter->data /*, factor, xoff, yoff*/);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -332,8 +332,9 @@ skippy_run(MainWin *mw, dlist *clients, Window focus, Window leader, Bool all_xi
 		XFlush(ps->dpy);
 	}
 	
-	float anim_t=0.f;	// disabled. to enable, set to 0.0
-	float anim_time=0.2f;	// slow for debug
+	float anim_time=ps->o.animTime;	// slow for debug
+	float anim_t=(anim_time<=0.f)?anim_t=1.0:0.0f;
+
 	clients = do_layout(mw, clients, focus, leader,anim_t);
 	if (!mw->cod) {
 		printfef("(): No client windows found.");
@@ -826,6 +827,7 @@ int main(int argc, char *argv[]) {
 			config_get_bool_wrap(config, "tooltip", "followsMouse", &ps->o.tooltip_followsMouse);
 			config_get_int_wrap(config, "tooltip", "offsetX", &ps->o.tooltip_offsetX, INT_MIN, INT_MAX);
 			config_get_int_wrap(config, "tooltip", "offsetY", &ps->o.tooltip_offsetY, INT_MIN, INT_MAX);
+			config_get_float_wrap(config, "general", "animTime", &ps->o.animTime, 0.0f, 2.0f);
 			if (!parse_align(ps, config_get(config, "tooltip", "align", "left"), &ps->o.tooltip_align))
 				return RET_BADARG;
 			config_get_int_wrap(config, "tooltip", "tintOpacity", &ps->o.highlight_tintOpacity, 0, 256);

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -192,7 +192,7 @@ do_layout(MainWin *mw, dlist *clients, Window focus, Window leader,float t)
 		clientwin_map((ClientWin*)iter->data);
 	if (ps->o.movePointerOnStart)
 		XWarpPointer(mw->ps->dpy, None, mw->focus->mini.window, 0, 0, 0, 0,
-				mw->focus->mini.width / 2, mw->focus->mini.height / 2);
+				sw_width(&mw->focus->mini) / 2, sw_height(&mw->focus->mini) / 2);
 	
 	return clients;
 }

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -142,7 +142,7 @@ typedef struct {
 	.runAsDaemon = false, \
 	.synchronize = false, \
 \
-	.distance = 50, \
+	.distance = 8, \
 	.useNetWMFullscreen = true, \
 	.ignoreSkipTaskbar = false, \
 	.updateFreq = 10.0, \
@@ -153,9 +153,9 @@ typedef struct {
 	.xinerama_showAll = false, \
 	.normal_tint = NULL, \
 	.normal_tintOpacity = 0, \
-	.normal_opacity = 200, \
+	.normal_opacity = 248, \
 	.highlight_tint = NULL, \
-	.highlight_tintOpacity = 64, \
+	.highlight_tintOpacity = 32, \
 	.highlight_opacity = 255, \
 	.tooltip_show = true, \
 	.tooltip_followsMouse = true, \
@@ -444,6 +444,8 @@ ev_key_str(XKeyEvent *ev) {
 #include "tooltip.h"
 
 extern session_t *ps_g;
+
+#define logd //
 
 #define ACTIVATE_WINDOW_PICKER 1
 #define EXIT_RUNNING_DAEMON 2

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -173,7 +173,7 @@ typedef struct {
 	.tooltip_text = NULL, \
 	.tooltip_textShadow = NULL, \
 	.tooltip_font = NULL, \
-	.animTime = 0.15f \
+	.animTime = 0.f \
 }
 
 /// @brief X information structure.

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -173,7 +173,7 @@ typedef struct {
 	.tooltip_text = NULL, \
 	.tooltip_textShadow = NULL, \
 	.tooltip_font = NULL, \
-	.animTime = 0.2f \
+	.animTime = 0.15f \
 }
 
 /// @brief X information structure.

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -112,6 +112,9 @@ typedef struct {
 	bool movePointerOnStart;
 
 	bool xinerama_showAll;
+	bool layout_desktop;
+	bool layout_grid;
+	bool layout_smart;
 
 	char *normal_tint;
 	int normal_tintOpacity;

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -136,6 +136,8 @@ typedef struct {
 	char *tooltip_textShadow;
 	char *tooltip_font;
 
+	float	animTime;
+
 	enum cliop bindings_miwMouse[MAX_MOUSE_BUTTONS];
 } options_t;
 
@@ -171,6 +173,7 @@ typedef struct {
 	.tooltip_text = NULL, \
 	.tooltip_textShadow = NULL, \
 	.tooltip_font = NULL, \
+	.animTime = 0.2f \
 }
 
 /// @brief X information structure.
@@ -255,6 +258,8 @@ allocchk_(void *ptr, const char *func_name) {
 	for(; iter; iter = iter->next) \
 		statement; \
 }
+
+#define LET(varname,expr) typeof(expr) varname = expr;
 
 /**
  * @brief Get current time, in milliseconds.

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -259,7 +259,17 @@ allocchk_(void *ptr, const char *func_name) {
 		statement; \
 }
 
+#ifndef TYPEOF
+#ifdef __cplusplus
+	#define TYPEOF __decltype
+#else 
+	#define TYPEOF typeof
+#endif
+#endif
 #define LET(varname,expr) typeof(expr) varname = expr;
+#define MALLOCS(TYPE,COUNT) ((TYPE*)malloc(sizeof(TYPE)*COUNT))
+#define REALLOCS(ptr,COUNT) ((TYPEOF(ptr)realloc(ptr,sizeof(*ptr)*COUNT))
+#define FREE(PTR) {if (PTR) {free((void*)(PTR)); PTR=0;}}
 
 /**
  * @brief Get current time, in milliseconds.

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -438,6 +438,7 @@ ev_key_str(XKeyEvent *ev) {
 	printfef("(): KeyRelease %u (%s) not binded to anything.", \
 			(ev)->xkey.keycode, ev_key_str(&(ev)->xkey))
 
+#include "vecmath2d.h"
 #include "wm.h"
 #include "clientwin.h"
 #include "mainwin.h"

--- a/src/vecmath2d.h
+++ b/src/vecmath2d.h
@@ -1,0 +1,129 @@
+#ifndef vecmath2d_h
+#define vecmath2d_h
+
+// 2d int maths helpers
+typedef struct Vec2i {	// todo: refactor to use this
+	int x,y;
+} Vec2i;
+
+// rectangular region
+typedef struct Rect2i {
+	Vec2i min,max;
+} Rect2i;
+
+// alternative way of specifying rectangle
+typedef struct PosSize {
+	Vec2i pos,size;
+} PosSize;
+
+
+inline int invlerpi(int lo,int hi,int v,int one) {
+	return ((v-lo)*one)/(hi-lo);
+}
+inline int lerpi(int lo,int hi,int f,int one) {
+	return lo+(((hi-lo)*f)/one);
+}
+inline void v2i_set(Vec2i* dst, int x, int y) {
+	dst->x=x;dst->y=y;
+}
+inline Vec2i vec2i_mk(int x, int y) {
+	Vec2i v; v.x=x; v.y=y; return v;
+}
+inline Vec2i v2i_sub(Vec2i a,Vec2i b) {
+	Vec2i ret= {a.x-b.x,a.y-b.y};return ret;
+}
+inline Vec2i v2i_add(Vec2i a,Vec2i b) {
+	Vec2i ret= {a.x+b.x,a.y+b.y};return ret; 
+}
+inline Vec2i v2i_mul(Vec2i a,int f,int prec) {
+	Vec2i ret= {(a.x*f)/prec,(a.y*f)/prec};return ret; 
+}
+inline Vec2i v2i_avr(Vec2i a,Vec2i b) {
+	Vec2i ret=v2i_mul(v2i_add(a,b),1,2); return ret;
+}
+inline Vec2i v2i_mad(Vec2i a,Vec2i b,int f,int prec) {
+	return v2i_add(a, v2i_mul(b,f,prec)); 
+}
+inline Vec2i v2i_lerp(Vec2i a,Vec2i b,int f,int prec) {
+	return v2i_add(a, v2i_mul(v2i_sub(b,a),f,prec)); 
+}
+inline Vec2i v2i_invlerp(const Vec2i vmin,const Vec2i vmax, Vec2i v,int precision ) {
+	Vec2i ret={invlerpi(vmin.x, vmax.x, v.x,precision), invlerpi(vmin.y, vmax.y, v.y,precision)}; return ret;
+}
+inline Vec2i rect2i_lerp(const Rect2i* r, Vec2i v, int precision) {
+	Vec2i ret; ret.x=lerpi(r->min.x,r->max.x, v.x,precision); ret.y=lerpi(r->min.y,r->max.y, v.y,precision); return ret;
+}
+inline Vec2i rect2i_invlerp(const Rect2i* r, Vec2i v, int precision) {
+	return v2i_invlerp(r->min,r->max, v, precision);
+}
+inline Vec2i v2i_min(Vec2i a,Vec2i b) {
+	Vec2i ret={MIN(a.x,b.x),MIN(a.y,b.y)}; return ret;
+}
+inline Vec2i v2i_max(Vec2i a,Vec2i b) {
+	Vec2i ret={MAX(a.x,b.x),MAX(a.y,b.y)}; return ret;
+}
+inline Rect2i rect2i_init(void){
+	Rect2i ret={{INT_MAX,INT_MAX},{-INT_MAX,-INT_MAX}}; return ret;
+}
+inline Rect2i rect2i_mk_at(Vec2i pos, Vec2i size){
+	Rect2i ret; ret.min=pos; ret.max=v2i_add(pos,size);  return ret;
+}
+inline Rect2i rect2i_mk_at_centre(Vec2i centre, Vec2i half_size){
+	Rect2i ret; ret.min=v2i_sub(centre,half_size); ret.max=v2i_add(centre,half_size);  return ret;
+}
+inline Rect2i rect2i_mk(Vec2i a, Vec2i b){
+	Rect2i ret; ret.min=a; ret.max=b;  return ret;
+}
+inline void rect2i_set_init(Rect2i* ret){ 
+	v2i_set(&ret->min,INT_MAX,INT_MAX);v2i_set(&ret->max,-INT_MAX,-INT_MAX);
+}
+inline void rect2i_include(Rect2i* r,Vec2i v){
+	r->min=v2i_min(r->min,v); r->max=v2i_max(r->max,v);
+}
+inline void rect2i_include_rect2i(Rect2i* r,const Rect2i* src){
+	r->min=v2i_min(r->min,src->min);r->max=v2i_max(r->max,src->max);
+}
+inline Vec2i rect2i_size(const Rect2i* r) {
+	return v2i_sub(r->max,r->min);
+}
+inline int rect2i_aspect(const Rect2i* r,int precision) {
+	Vec2i sz=rect2i_size(r); return (sz.x*precision)/sz.y;
+}
+inline Rect2i rect2i_add(const Rect2i* a, Vec2i ofs) {
+	Rect2i ret={v2i_add(a->min,ofs),v2i_add(a->max,ofs)}; return ret;
+}
+inline int rect2i_area( const Rect2i* r,int denom) {
+	Vec2i sz=rect2i_size(r); return (sz.x*sz.y/denom);
+}
+inline Rect2i rect2i_intersect( const Rect2i* a,const Rect2i* b ) {
+	Rect2i r; r.min=v2i_max(a->min,b->min); r.max=v2i_min(a->max,b->max); return r;
+}
+inline int rect2i_overlap( const Rect2i* a,const Rect2i* b) {
+	Rect2i ri=rect2i_intersect(a,b);Vec2i sz= rect2i_size(&ri);if (sz.x>0 && sz.y>0) return sz.x*sz.y; else return 0;
+}
+inline bool rect2i_contains( const Rect2i* rc, const Vec2i v){
+	return v.x>=rc->min.x && v.x<rc->max.x && v.y>=rc->min.y && v.y<rc->max.y;
+}
+inline bool rect2i_valid(const Rect2i* a) {
+	return a->max.x>=a->min.x && a->max.y >= a->min.y;
+}
+inline void vec2i_print(const Vec2i v) {
+	printf("(%d %d)", v.x,v.y);
+}
+inline void rect2i_print(const Rect2i* a) {
+	printf("("); vec2i_print(a->min); printf(" "); vec2i_print(a->max); printf(")");
+}
+inline Vec2i rect2i_centre(const Rect2i* r) {
+	return v2i_avr(r->min,r->max);
+}
+inline PosSize pos_size_mk(const Vec2i pos, const Vec2i size) {
+	PosSize psz;psz.pos=pos; psz.size=size; return psz;
+}
+inline PosSize pos_size_from_rect(const Rect2i* r) {
+	PosSize psz;psz.pos=r->min; psz.size=rect2i_size(r); return psz;
+}
+inline Rect2i rect2i_from_pos_size(const PosSize* psz)
+{	rect2i_mk_at(psz->pos, psz->size);
+}
+
+#endif

--- a/src/vecmath2d.h
+++ b/src/vecmath2d.h
@@ -2,6 +2,12 @@
 #define vecmath2d_h
 
 // 2d int maths  - types and inline helper functions/accessors
+//
+// type_op_(optional types, usually same as type if not mentioned)
+// common type vec2i has abreviation v2i_
+// type_set -- setter 
+// type_noun/adj -- getter 
+// type_verb/question -- calculate something
 
 typedef int VScalar;	// Scalar value used here. TODO: int? i32?  i64? :)
 typedef struct Vec2i {	// todo: refactor to use this
@@ -113,8 +119,8 @@ inline int rect2i_area( const Rect2i* r,VScalar denom) {
 inline PosSize rect2i_pos_size(const Rect2i* r) {
 	PosSize psz; psz.pos=r->min; psz.size=v2i_sub(r->max,r->min); return psz;
 }
-inline void rect2i_set(Rect2i* rc, const Vec2i* a, const Vec2i* b) { rc->min=*a; rc->max=*b;}
-inline void rect2i_set_pos_size(Rect2i* rc, const Vec2i* pos, const Vec2i* size) { rc->min=*pos;rc->max=v2i_add(*pos,*size);}
+inline void rect2i_set(Rect2i* rc, const Vec2i a, const Vec2i b) { rc->min=a; rc->max=b;}
+inline void rect2i_set_pos_size(Rect2i* rc, const Vec2i pos, const Vec2i size) { rc->min=pos;rc->max=v2i_add(pos,size);}
 inline VScalar rect2i_width(const Rect2i* r) { return rect2i_size(r).x;}
 inline VScalar rect2i_height(const Rect2i* r) { return rect2i_size(r).y;}
 inline Rect2i rect2i_intersect( const Rect2i* a,const Rect2i* b ) {
@@ -131,6 +137,10 @@ inline bool rect2i_overlap( const Rect2i* ra, const Rect2i* rb){
 	if (ra->max.x<=rb->min.x || ra->min.x>=rb->max.x) return false;
 	if (ra->max.y<=rb->min.y || ra->min.y>=rb->max.y) return false;
 	return 	true;
+}
+inline void rect2i_set_centre(Rect2i* rc, const Vec2i new_centre) {
+	Vec2i size=rect2i_size(rc);
+	rect2i_set_pos_size(rc, v2i_sub(new_centre, v2i_half(size)), size);
 }
 inline void rect2i_split_x(Rect2i* out0, Rect2i* out1,VScalar split, const Rect2i* rc ) {
 	out0->min=rc->min;

--- a/src/vecmath2d.h
+++ b/src/vecmath2d.h
@@ -1,33 +1,41 @@
 #ifndef vecmath2d_h
 #define vecmath2d_h
 
-// 2d int maths helpers
+// 2d int maths  - types and inline helper functions/accessors
+
+typedef int VScalar;	// Scalar value used here. TODO: int? i32?  i64? :)
 typedef struct Vec2i {	// todo: refactor to use this
-	int x,y;
+	VScalar x,y;
 } Vec2i;
 
-// rectangular region
+// rectangular region, aka RECT, AABB,   'Extents<Vec2i>'
 typedef struct Rect2i {
 	Vec2i min,max;
 } Rect2i;
 
-// alternative way of specifying rectangle
+// alternative way of specifying rectanglular region
 typedef struct PosSize {
 	Vec2i pos,size;
 } PosSize;
 
+#ifndef CLAMP
+#define CLAMP(V,LO,HI) (MIN(HI,(MAX(LO,V))))
+#endif
 
-inline int invlerpi(int lo,int hi,int v,int one) {
+inline VScalar invlerpi(VScalar lo,VScalar hi,VScalar v,int one) {
 	return ((v-lo)*one)/(hi-lo);
 }
-inline int lerpi(int lo,int hi,int f,int one) {
+inline int lerpi(VScalar lo,VScalar hi,VScalar f,VScalar one) {
 	return lo+(((hi-lo)*f)/one);
 }
-inline void v2i_set(Vec2i* dst, int x, int y) {
+inline void v2i_set(Vec2i* dst, VScalar x, VScalar y) {
 	dst->x=x;dst->y=y;
 }
-inline Vec2i vec2i_mk(int x, int y) {
+inline Vec2i vec2i_mk(VScalar x, VScalar y) {
 	Vec2i v; v.x=x; v.y=y; return v;
+}
+inline Vec2i vec2i_splat(VScalar v) {
+	return	vec2i_mk(v,v);
 }
 inline Vec2i v2i_sub(Vec2i a,Vec2i b) {
 	Vec2i ret= {a.x-b.x,a.y-b.y};return ret;
@@ -35,25 +43,30 @@ inline Vec2i v2i_sub(Vec2i a,Vec2i b) {
 inline Vec2i v2i_add(Vec2i a,Vec2i b) {
 	Vec2i ret= {a.x+b.x,a.y+b.y};return ret; 
 }
-inline Vec2i v2i_mul(Vec2i a,int f,int prec) {
+inline Vec2i v2i_mul(Vec2i a,VScalar f,VScalar prec) {
 	Vec2i ret= {(a.x*f)/prec,(a.y*f)/prec};return ret; 
+}
+inline Vec2i v2i_half(Vec2i a) {
+	return vec2i_mk(a.x/2,a.y/2);
 }
 inline Vec2i v2i_avr(Vec2i a,Vec2i b) {
 	Vec2i ret=v2i_mul(v2i_add(a,b),1,2); return ret;
 }
-inline Vec2i v2i_mad(Vec2i a,Vec2i b,int f,int prec) {
+inline Vec2i v2i_mad(Vec2i a,Vec2i b,VScalar f,VScalar prec) {
 	return v2i_add(a, v2i_mul(b,f,prec)); 
 }
-inline Vec2i v2i_lerp(Vec2i a,Vec2i b,int f,int prec) {
+inline Vec2i v2i_lerp(Vec2i a,Vec2i b,VScalar f,VScalar prec) {
 	return v2i_add(a, v2i_mul(v2i_sub(b,a),f,prec)); 
 }
-inline Vec2i v2i_invlerp(const Vec2i vmin,const Vec2i vmax, Vec2i v,int precision ) {
+inline Vec2i v2i_invlerp(const Vec2i vmin,const Vec2i vmax, Vec2i v,VScalar precision ) {
 	Vec2i ret={invlerpi(vmin.x, vmax.x, v.x,precision), invlerpi(vmin.y, vmax.y, v.y,precision)}; return ret;
 }
-inline Vec2i rect2i_lerp(const Rect2i* r, Vec2i v, int precision) {
+// turn a fractional position into a position within a rect
+inline Vec2i rect2i_lerp(const Rect2i* r, Vec2i v, VScalar precision) {
 	Vec2i ret; ret.x=lerpi(r->min.x,r->max.x, v.x,precision); ret.y=lerpi(r->min.y,r->max.y, v.y,precision); return ret;
 }
-inline Vec2i rect2i_invlerp(const Rect2i* r, Vec2i v, int precision) {
+// get a vector which is the fractional position of a point in a rect
+inline Vec2i rect2i_invlerp(const Rect2i* r, Vec2i v, VScalar precision) {
 	return v2i_invlerp(r->min,r->max, v, precision);
 }
 inline Vec2i v2i_min(Vec2i a,Vec2i b) {
@@ -77,32 +90,65 @@ inline Rect2i rect2i_mk(Vec2i a, Vec2i b){
 inline void rect2i_set_init(Rect2i* ret){ 
 	v2i_set(&ret->min,INT_MAX,INT_MAX);v2i_set(&ret->max,-INT_MAX,-INT_MAX);
 }
+// expand a rectangle to include a vector
 inline void rect2i_include(Rect2i* r,Vec2i v){
 	r->min=v2i_min(r->min,v); r->max=v2i_max(r->max,v);
 }
+// expand a rect to include a rect
 inline void rect2i_include_rect2i(Rect2i* r,const Rect2i* src){
 	r->min=v2i_min(r->min,src->min);r->max=v2i_max(r->max,src->max);
 }
 inline Vec2i rect2i_size(const Rect2i* r) {
 	return v2i_sub(r->max,r->min);
 }
-inline int rect2i_aspect(const Rect2i* r,int precision) {
+inline int rect2i_aspect(const Rect2i* r,VScalar precision) {
 	Vec2i sz=rect2i_size(r); return (sz.x*precision)/sz.y;
 }
 inline Rect2i rect2i_add(const Rect2i* a, Vec2i ofs) {
 	Rect2i ret={v2i_add(a->min,ofs),v2i_add(a->max,ofs)}; return ret;
 }
-inline int rect2i_area( const Rect2i* r,int denom) {
+inline int rect2i_area( const Rect2i* r,VScalar denom) {
 	Vec2i sz=rect2i_size(r); return (sz.x*sz.y/denom);
 }
+inline PosSize rect2i_pos_size(const Rect2i* r) {
+	PosSize psz; psz.pos=r->min; psz.size=v2i_sub(r->max,r->min); return psz;
+}
+inline void rect2i_set(Rect2i* rc, const Vec2i* a, const Vec2i* b) { rc->min=*a; rc->max=*b;}
+inline void rect2i_set_pos_size(Rect2i* rc, const Vec2i* pos, const Vec2i* size) { rc->min=*pos;rc->max=v2i_add(*pos,*size);}
+inline VScalar rect2i_width(const Rect2i* r) { return rect2i_size(r).x;}
+inline VScalar rect2i_height(const Rect2i* r) { return rect2i_size(r).y;}
 inline Rect2i rect2i_intersect( const Rect2i* a,const Rect2i* b ) {
 	Rect2i r; r.min=v2i_max(a->min,b->min); r.max=v2i_min(a->max,b->max); return r;
 }
-inline int rect2i_overlap( const Rect2i* a,const Rect2i* b) {
+inline VScalar rect2i_overlap_area( const Rect2i* a,const Rect2i* b) {
 	Rect2i ri=rect2i_intersect(a,b);Vec2i sz= rect2i_size(&ri);if (sz.x>0 && sz.y>0) return sz.x*sz.y; else return 0;
 }
 inline bool rect2i_contains( const Rect2i* rc, const Vec2i v){
 	return v.x>=rc->min.x && v.x<rc->max.x && v.y>=rc->min.y && v.y<rc->max.y;
+}
+inline bool rect2i_overlap( const Rect2i* ra, const Rect2i* rb){
+	//if boundaries touch, area of overlap is still zero
+	if (ra->max.x<=rb->min.x || ra->min.x>=rb->max.x) return false;
+	if (ra->max.y<=rb->min.y || ra->min.y>=rb->max.y) return false;
+	return 	true;
+}
+inline void rect2i_split_x(Rect2i* out0, Rect2i* out1,VScalar split, const Rect2i* rc ) {
+	out0->min=rc->min;
+	out0->max.x=split;
+	out0->max.y=rc->max.y;
+
+	out1->min.x=split;
+	out1->min.y=rc->min.y;
+	out1->max=rc->max;
+}
+inline void rect2i_split_y(Rect2i* out0, Rect2i* out1,VScalar split, const Rect2i* rc ) {
+	out0->min=rc->min;
+	out0->max.y=split;
+	out0->max.x=rc->max.x;
+
+	out1->min.y=split;
+	out1->min.x=rc->min.x;
+	out1->max=rc->max;
 }
 inline bool rect2i_valid(const Rect2i* a) {
 	return a->max.x>=a->min.x && a->max.y >= a->min.y;
@@ -119,8 +165,12 @@ inline Vec2i rect2i_centre(const Rect2i* r) {
 inline PosSize pos_size_mk(const Vec2i pos, const Vec2i size) {
 	PosSize psz;psz.pos=pos; psz.size=size; return psz;
 }
+inline void pos_size_set_rect(PosSize* psz, const Rect2i* r) {
+	psz->pos=r->min;
+	psz->size=rect2i_size(r);
+}
 inline PosSize pos_size_from_rect(const Rect2i* r) {
-	PosSize psz;psz.pos=r->min; psz.size=rect2i_size(r); return psz;
+	PosSize psz;pos_size_set_rect(&psz,r); return psz;
 }
 inline Rect2i rect2i_from_pos_size(const PosSize* psz)
 {	rect2i_mk_at(psz->pos, psz->size);

--- a/src/wm.c
+++ b/src/wm.c
@@ -332,6 +332,7 @@ wm_get_stack(Display *dpy)
 	{
 		l = dlist_add(l, (void *)((long *)data)[i]);
 	}
+	printf("read %d in stack\n",items_read);
 	
 	XFree(data);
 	
@@ -491,6 +492,7 @@ wm_validate_window(Display *dpy, Window win)
 	Atom real_type;
 	unsigned long items_read, items_left, i;
 	int result = 1;
+	printf("validate call\n");
 	
 	if(WM_PERSONALITY == WM_PERSONALITY_NETWM)
 	{
@@ -498,15 +500,18 @@ wm_validate_window(Display *dpy, Window win)
 		                  0L, 8192L, False, XA_ATOM, &real_type, &real_format,
 		                  &items_read, &items_left, &data);
 		
-		if(status != Success)
+		if(status != Success) {
+			printf("prop failed\n");
 			return 0;
+		}
 		
 		atoms = (Atom *)data;
 		
 		for(i = 0; result && i < items_read; i++) {
 			if(atoms[i] == _NET_WM_STATE_HIDDEN)
 				result = 0;
-			else if(! IGNORE_SKIP_TASKBAR && atoms[i] == _NET_WM_STATE_SKIP_TASKBAR)
+			else 
+			if(! IGNORE_SKIP_TASKBAR && atoms[i] == _NET_WM_STATE_SKIP_TASKBAR)
 				result = 0;
 			else if(atoms[i] == _NET_WM_STATE_SHADED)
 				result = 0;
@@ -515,8 +520,10 @@ wm_validate_window(Display *dpy, Window win)
 		}
 		XFree(data);
 		
-		if(! result)
+		if(! result) {
+			printf("hidden/skip/taskbar\n");
 			return 0;
+		}
 		
 		status = XGetWindowProperty(dpy, win, _NET_WM_WINDOW_TYPE,
 		                            0L, 1L, False, XA_ATOM, &real_type, &real_format,
@@ -526,8 +533,10 @@ wm_validate_window(Display *dpy, Window win)
 		
 		atoms = (Atom *)data;
 		
-		if(items_read && (atoms[0] == _NET_WM_WINDOW_TYPE_DESKTOP || atoms[0] == _NET_WM_WINDOW_TYPE_DOCK))
+		if(items_read && (atoms[0] == _NET_WM_WINDOW_TYPE_DESKTOP || atoms[0] == _NET_WM_WINDOW_TYPE_DOCK)) {
+			printf("dock\n");
 			result = 0;
+		}
 		
 		XFree(data);
 		
@@ -542,16 +551,20 @@ wm_validate_window(Display *dpy, Window win)
 		{
 			if(status == Success)
 				XFree(data);
+			printf("status\n");
 			return 0;
 		}
 		attr = (((CARD32*)data)[0]) & (WIN_STATE_MINIMIZED |
 		                             WIN_STATE_SHADED |
 		                             WIN_STATE_HIDDEN);
-		if(attr)
+		if(attr) {
 			result = 0;
+		}
 		XFree(data);
-		if(! result)
+		if(! result){
+			printf("hidden/skip/taskbar\n");
 			return 0;
+		}
 		
 		if(! IGNORE_SKIP_TASKBAR)
 		{
@@ -565,8 +578,10 @@ wm_validate_window(Display *dpy, Window win)
 				return 1; /* If there's no _WIN_HINTS, assume it's 0, thus valid */
 			}
 			attr = ((CARD32*)data)[0];
-			if(attr & WIN_HINTS_SKIP_TASKBAR)
+			if(attr & WIN_HINTS_SKIP_TASKBAR) {
+				printf("taskbar\n");
 				result = 0;
+			}
 			XFree(data);
 		}
 		

--- a/src/wm.c
+++ b/src/wm.c
@@ -332,7 +332,6 @@ wm_get_stack(Display *dpy)
 	{
 		l = dlist_add(l, (void *)((long *)data)[i]);
 	}
-	printf("read %d in stack\n",items_read);
 	
 	XFree(data);
 	
@@ -492,7 +491,6 @@ wm_validate_window(Display *dpy, Window win)
 	Atom real_type;
 	unsigned long items_read, items_left, i;
 	int result = 1;
-	printf("validate call\n");
 	
 	if(WM_PERSONALITY == WM_PERSONALITY_NETWM)
 	{
@@ -501,7 +499,6 @@ wm_validate_window(Display *dpy, Window win)
 		                  &items_read, &items_left, &data);
 		
 		if(status != Success) {
-			printf("prop failed\n");
 			return 0;
 		}
 		
@@ -521,7 +518,6 @@ wm_validate_window(Display *dpy, Window win)
 		XFree(data);
 		
 		if(! result) {
-			printf("hidden/skip/taskbar\n");
 			return 0;
 		}
 		
@@ -534,7 +530,6 @@ wm_validate_window(Display *dpy, Window win)
 		atoms = (Atom *)data;
 		
 		if(items_read && (atoms[0] == _NET_WM_WINDOW_TYPE_DESKTOP || atoms[0] == _NET_WM_WINDOW_TYPE_DOCK)) {
-			printf("dock\n");
 			result = 0;
 		}
 		
@@ -562,7 +557,6 @@ wm_validate_window(Display *dpy, Window win)
 		}
 		XFree(data);
 		if(! result){
-			printf("hidden/skip/taskbar\n");
 			return 0;
 		}
 		
@@ -579,7 +573,6 @@ wm_validate_window(Display *dpy, Window win)
 			}
 			attr = ((CARD32*)data)[0];
 			if(attr & WIN_HINTS_SKIP_TASKBAR) {
-				printf("taskbar\n");
 				result = 0;
 			}
 			XFree(data);


### PR DESCRIPTION
added "expo"(spaces) style mode, with commandline option eg skippy-xd -ad
refactored some layout code to seperate X11 stuff from layout calc
added some vec maths helpers, 

the 'expo' style mode is different to others that its rescaled to only show the acoverlap tually used area. 
if you have 2x2 used out of 3x3.. it only shows that much.

I want to do a bit more, what I have in mind is an option to automatically pick expo/scale based on whats actually on the current screen. (if  (windows are hidden by overlap) then 'scale' else 'expo');
also i'd like to implement a grid layout option, easier to navigate with cursors a. Independant scaling is why i've refactored the layout calc

extra options so far (they can go in config too)
skippy-xd  -a  // force gathering windows from all desktops
skippy-xd -ad // force gather from all desktops , plus keep desktop layout.

I use this with "fvwm" at the minute. I like a minimal desktop on my laptop... its a very handy setup.
but I'm inspired by the experience of a mac where expose+spaces and mission control were genuinely more useful than anything i've found in linux. 
It should just take a small amount of smart-triggering to get the same functionality. just one hotkey or mouse gesture to 'zoom out more' and one to 'select perhaps 
eg start->
press hotkey -> see expo/scale based on context
-> if you didn't you see what you want,
-> press same one again -> combined expo+scale views everything , but more zoomed
.. that sort of thing

I've embarked on customizing 'skippy' instead of compiz because I haven't got the latter to compile yet :)

NOTE:-
I also changed some defaults in the config file, i hope they're ok
I like to be able to actually read the text in the previews.. so i've upped the default opacity to 248 , and  reduced border sizes to 8 pixels - I
