### PR TITLE
Config variables preventing stealing the pointer in some cases

### DIFF
--- a/src/clientwin.c
+++ b/src/clientwin.c
@@ -337,7 +337,10 @@ clientwin_unmap(ClientWin *cw)
 
 static void
 childwin_focus(ClientWin *cw) {
-	XWarpPointer(cw->mainwin->ps->dpy, None, cw->wid_client, 0, 0, 0, 0, cw->src.width / 2, cw->src.height / 2);
+	session_t * const ps = cw->mainwin->ps;
+
+	if (ps->o.movePointerOnRaise)
+		XWarpPointer(cw->mainwin->ps->dpy, None, cw->wid_client, 0, 0, 0, 0, cw->src.width / 2, cw->src.height / 2);
 	XRaiseWindow(cw->mainwin->ps->dpy, cw->wid_client);
 	XSetInputFocus(cw->mainwin->ps->dpy, cw->wid_client, RevertToParent, CurrentTime);
 }

--- a/src/focus.c
+++ b/src/focus.c
@@ -28,6 +28,7 @@ dir_focus(ClientWin *cw, match_func match, dist_func func)
 	float diff = 0.0;
 	ClientWin *candidate = NULL;
 	dlist *iter, *candidates;
+	session_t * const ps = cw->mainwin->ps;
 	
 	candidates = dlist_first(dlist_find_all(cw->mainwin->cod, (dlist_match_func)match, &cw->mini));
 	if(! candidates)
@@ -44,7 +45,8 @@ dir_focus(ClientWin *cw, match_func match, dist_func func)
 		}
 	}
 	
-	XWarpPointer(candidate->mainwin->ps->dpy, None, candidate->mini.window, 0, 0, 0, 0, candidate->mini.width / 2, candidate->mini.height / 2);
+	if (ps->o.movePointerOnSelect)
+		XWarpPointer(candidate->mainwin->ps->dpy, None, candidate->mini.window, 0, 0, 0, 0, candidate->mini.width / 2, candidate->mini.height / 2);
 	XSetInputFocus(candidate->mainwin->ps->dpy, candidate->mini.window, RevertToParent, CurrentTime);
 	dlist_free(candidates);
 }

--- a/src/skippy.c
+++ b/src/skippy.c
@@ -983,6 +983,8 @@ int main(int argc, char *argv[]) {
 			config_get_bool_wrap(config, "general", "useNameWindowPixmap", &ps->o.useNameWindowPixmap);
 			config_get_bool_wrap(config, "general", "includeFrame", &ps->o.includeFrame);
 			config_get_bool_wrap(config, "general", "movePointerOnStart", &ps->o.movePointerOnStart);
+			config_get_bool_wrap(config, "general", "movePointerOnSelect", &ps->o.movePointerOnSelect);
+			config_get_bool_wrap(config, "general", "movePointerOnRaise", &ps->o.movePointerOnRaise);
 			config_get_bool_wrap(config, "xinerama", "showAll", &ps->o.xinerama_showAll);
 			config_get_int_wrap(config, "normal", "tintOpacity", &ps->o.normal_tintOpacity, 0, 256);
 			config_get_int_wrap(config, "normal", "opacity", &ps->o.normal_opacity, 0, 256);

--- a/src/skippy.h
+++ b/src/skippy.h
@@ -192,6 +192,8 @@ typedef struct {
 	bool includeFrame;
 	char *pipePath;
 	bool movePointerOnStart;
+	bool movePointerOnSelect;
+	bool movePointerOnRaise;
 	bool includeAllScreens;
 	char *buttonImgs[NUM_BUTN];
 	pictw_t *background;
@@ -238,6 +240,8 @@ typedef struct {
 	.includeFrame = false, \
 	.pipePath = NULL, \
 	.movePointerOnStart = true, \
+	.movePointerOnSelect = true, \
+	.movePointerOnRaise = true, \
 	.includeAllScreens = false, \
 	.buttonImgs = { NULL }, \
 	.background = NULL, \


### PR DESCRIPTION
This commit adds a couple of config variables that prevent stealing the pointer when selecting a mini-window and raising a real window.
