### PR TITLE
DGifCloseFile signature changed: fixes build against giflib 5.1.0

### DIFF
--- a/src/img-gif.c
+++ b/src/img-gif.c
@@ -146,8 +146,12 @@ sgif_read_end:
 	if (data)
 		free(data);
 	if (likely(f)){
+#ifdef SGIF_THREADSAFE
 		int err;
 		DGifCloseFile(f, &err);
+#else
+		DGifCloseFile(f);
+#endif	
 	}
 
 	return pictw;


### PR DESCRIPTION
I just tried to build skippy-xd on arch linux, but it failed (even though it did work 2 days ago).

I'm using this package build in the user repository:
https://aur.archlinux.org/packages/skippy-xd-git/

I'm not sure about the versioning of libgif, but this patch is necessary for skippy-xd to compile and work at least on arch.

Here's the line in the giflib header:
http://sourceforge.net/p/giflib/code/ci/master/tree/lib/gif_lib.h#l183
