### PR TITLE
Converted the README to markdown merged from the google code wiki

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,6 +1,0 @@
-link:https://code.google.com/p/skippy-xd/[Skippy-XD] -- a full-screen task-switcher for X11. 
-
-This GitHub repo hosts the code of a fork from the original 0.5.0 release (2004), initially maintained by Nick Watts (2011) and now by Richard Grenville (2013). The project's home page, downloads and wiki are hosted at link:https://code.google.com/p/skippy-xd/[Skippy-XD on Google Code]. An Ubuntu PPA for daily builds is available at link:https://launchpad.net/~landronimirc/+archive/skippy-xd-daily/[Skippy-XD PPA (daily)].
-
-
-image:https://badges.gitter.im/Join%20Chat.svg[link="https://gitter.im/richardgv/skippy-xd?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,100 @@
+# Skippy-XD
+
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/richardgv/skippy-xd)
+
+A full-screen expose-style task-switcher for X11.
+
+Originally mirrored from [the Google Code project](https://code.google.com/p/skippy-xd/) this GitHub repo hosts the code of a fork from the original 0.5.0 release (2004). That fork was initially maintained by Nick Watts (2011) and is now maintained by [Richard Grenville](https://github.com/richardgv) (2013).
+
+## Installation
+
+If you're using Ubuntu, you may simply install via the [Skippy-XD PPA.](https://launchpad.net/~landronimirc/+archive/skippy-xd) (or the [daily PPA](https://launchpad.net/~landronimirc/+archive/skippy-xd-daily/)).
+
+```sh
+sudo add-apt-repository ppa:landronimirc/skippy-xd
+sudo apt-get update
+sudo apt-get install skippy-xd
+```
+
+### From Source
+
+To compile Skippy-XD from source you need to install the following development packages:
+
+```sh
+apt-get install libimlib2-dev libfontconfig1-dev libfreetype6-dev libx11-dev libxext-dev libxft-dev 
+libxrender-dev zlib1g-dev libxinerama-dev libxcomposite-dev libxdamage-dev libxfixes-dev libxmu-dev
+```
+
+Now get the source, build and install:
+
+```sh
+git clone https://github.com/richardgv/skippy-xd.git
+cd skippy-xd
+make
+make install
+```
+
+## Usage
+
+### Config file
+
+Download the original `skippy-xd.rc-default` config file and copy it to `~/.config/skippy-xd/skippy-xd.rc` and edit it to your liking.
+
+### Command Line
+
+Once Skippy-XD is installed, you can run it by entering `skippy-xd` at the command line. This will start the program, activate the window picker once, then exit. However, starting the program produces a brief flicker, so its better to keep the application running in the background as a daemon and just activate it when you want to use the window picker.
+
+To run the daemon, use the following command:
+
+```sh
+skippy-xd --start-daemon
+```
+
+If for whatever reason you need to cleanly stop the running daemon, do this:
+
+```
+skippy-xd --stop-daemon
+```
+
+Once the daemon is running you can use the following command to activate it:
+
+```
+skippy-xd --activate-window-picker
+```
+
+However, sometimes pressing the Return key to run this last command also causes the window to be selected, so it is probably more effective in testing to do this:
+
+```
+sleep 1 && skippy-xd --activate-window-picker
+This will wait 1 second, then activate the picker.
+```
+
+### Keyboard Shortcuts
+
+Typically, it is helpful to set up keyboard shortcuts for skippy-xd. It is up to you to figure out how to set up keyboard shortcuts for your own window manager (it would be crazy to cover them all here). However, to get you started, here's some links:
+
+Xfce: http://wiki.xfce.org/faq#keyboard
+Openbox: https://urukrama.wordpress.com/openbox-guide/#Key_mouse
+Fluxbox: http://fluxbox-wiki.org/index.php/Keyboard_shortcuts#How_to_use_the_keys_file
+
+A good method is to set `skippy-xd --start-daemon` to be run after login, and bind a key (like **SUPER_L** [windows key] or **F9**) to `skippy-xd --activate-window-picker`.  Then the flicker mentioned above only happens when starting the daemon on login, and you are free to use the hotkey you bound to open skippy-xd.
+
+## Troubleshooting
+
+Admittedly, skippy-xd is not yet perfect. I find that sometimes it will just stop working. I'm not sure why yet (or else I'd fix it!), but it doesn't seem to be a crash (`ps aux | grep skippy` shows the daemon is still running).  To work around it I currently have a script in my home folder called `restart-skippy-xd.sh` that contains this:
+
+```
+#!/bin/sh
+killall skippy-xd
+rm /tmp/skippy-xd-fifo
+skippy-xd --start-daemon
+```
+
+Next, I bind this script to **CTRL+SHIFT+F9**. This means that when skippy-xd occasionally stops working, a quick **CTRL+SHIFT+F9**, then **F9** again and its back.
+
+If you installed it from the Skippy-XD PPA, then you're advised to use skippy-xd-activate to activate the task-switcher (if the daemon is already running); the simple bash script will introduce a small delay before calling Skippy-XD, and this tends to increase reliability. If the plugin has already crashed, then use a different keyboard shortcut for skippy-xd-restart, another simple script that will clean up and restart Skippy-XD daemon (the same as `restart-skippy-xd.sh` above).
+
+## See Also
+
+* [Skippy-XD on Ubuntu Wiki](https://wiki.ubuntu.com/Skippy)
+* [Skippy-XD on Google Code](https://code.google.com/p/skippy-xd/)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/richardgv/skippy-xd)
 
-A full-screen expose-style task-switcher for X11.
+A full-screen expose-style task-switcher for X11.  You know that thing Mac OS X, Gnome 3, Compiz and KWin do where you press a hotkey and suddenly you see miniature versions of all your windows at once? Skippy-XD does just that. It's most commonly known by Mac OS X's name for it - **Exposé**.  **You can see a demo on [YouTube](http://www.youtube.com/watch?v=gVRPCd7OS38).**
 
 Originally mirrored from [the Google Code project](https://code.google.com/p/skippy-xd/) this GitHub repo hosts the code of a fork from the original 0.5.0 release (2004). That fork was initially maintained by Nick Watts (2011) and is now maintained by [Richard Grenville](https://github.com/richardgv) (2013).
+
+So why do I want Skippy-XD instead of Mac OS X, Compiz or KWin? Well many Linux users prefer a lightweight, speedy desktop environment like Xfce, LXDE or their own Openbox-based hodge podge. Many even appreciate that these environments don't have compositing because it can degrade performance in some applications (especially 3D applications).
+
+Skippy-XD is a standalone application for providing a window picker with live previews (including live video) on Linux desktops that run an X server with compositing support. That means it's not baked into the window manager, and the compositing is not being used all the time. So the performance of you're window manager isn't degraded, but you still get a window picker that's every bit as pretty as OSX's Exposé or KWin's "Present Windows", with all the desktop-navigational efficiency. Compositing only takes effect when you press the hotkey to display the window picker.
 
 ## Installation
 
@@ -15,6 +19,8 @@ sudo add-apt-repository ppa:landronimirc/skippy-xd
 sudo apt-get update
 sudo apt-get install skippy-xd
 ```
+
+You can also check the [downloads page at the Google Code project](https://code.google.com/p/skippy-xd/downloads/list).
 
 ### From Source
 
@@ -98,3 +104,5 @@ If you installed it from the Skippy-XD PPA, then you're advised to use skippy-xd
 
 * [Skippy-XD on Ubuntu Wiki](https://wiki.ubuntu.com/Skippy)
 * [Skippy-XD on Google Code](https://code.google.com/p/skippy-xd/)
+* [Original home of Skippy-XD](http://thegraveyard.org/skippy.html)
+* [Skippy-XD on freecode](http://freecode.com/projects/skippy)

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ This will wait 1 second, then activate the picker.
 
 Typically, it is helpful to set up keyboard shortcuts for skippy-xd. It is up to you to figure out how to set up keyboard shortcuts for your own window manager (it would be crazy to cover them all here). However, to get you started, here's some links:
 
-Xfce: http://wiki.xfce.org/faq#keyboard
-Openbox: https://urukrama.wordpress.com/openbox-guide/#Key_mouse
-Fluxbox: http://fluxbox-wiki.org/index.php/Keyboard_shortcuts#How_to_use_the_keys_file
+* Xfce: http://wiki.xfce.org/faq#keyboard
+* Openbox: https://urukrama.wordpress.com/openbox-guide/#Key_mouse
+* Fluxbox: http://fluxbox-wiki.org/index.php/Keyboard_shortcuts#How_to_use_the_keys_file
 
 A good method is to set `skippy-xd --start-daemon` to be run after login, and bind a key (like **SUPER_L** [windows key] or **F9**) to `skippy-xd --activate-window-picker`.  Then the flicker mentioned above only happens when starting the daemon on login, and you are free to use the hotkey you bound to open skippy-xd.
 


### PR DESCRIPTION
This seems much nicer to me.  A single pretty file from which to get all the information you need to install and operate skippy-xd.
