### PR TITLE
Pipe file must be user-personal (uid-terminated pipe file name)

### DIFF
--- a/src/skippy.c
+++ b/src/skippy.c
@@ -1198,7 +1198,23 @@ int main(int argc, char *argv[]) {
 		// Read configuration into ps->o, because searching all the time is much
 		// less efficient, may introduce inconsistent default value, and
 		// occupies a lot more memory for non-string types.
-		ps->o.pipePath = mstrdup(config_get(config, "general", "pipePath", "/tmp/skippy-xd-fifo"));
+		{
+                // Appending UID to the file name
+                        // Dash-separated initial single-digit string
+                        int uid = (int)getuid(), pipeStrLen = 3;
+                        {
+                                int num;
+                                for (num = uid; num >= 10; num /= 10) pipeStrLen++;
+                        }
+
+                        unsigned char * path = config_get(config, "general", "pipePath", "/tmp/skippy-xd-fifo");
+                        pipeStrLen += strlen(path);
+
+                        unsigned char * pipePath = malloc (pipeStrLen * sizeof(unsigned char));
+                        sprintf(pipePath, "%s-%i", path, uid);
+
+                        ps->o.pipePath = pipePath;
+                }
 		ps->o.normal_tint = mstrdup(config_get(config, "normal", "tint", "black"));
 		ps->o.highlight_tint = mstrdup(config_get(config, "highlight", "tint", "#101020"));
 		ps->o.tooltip_border = mstrdup(config_get(config, "tooltip", "border", "#e0e0e0"));


### PR DESCRIPTION
Appends uid to pipe file name, loaded from settings, thus making it user-personal. When skippy-xd daemon is terminated instead of exiting by dedicated command, pipe file is not removed, what blocks it for other users.
